### PR TITLE
fix/pointer action ts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ node_modules
 /dist/
 cypress/videos
 cypress/screenshots
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "cypress run",
         "lint": "eslint .",
         "format": "prettier --write .",
-        "clean": "rm -r ./dist",
+        "clean": "rm -rf ./dist",
         "build": "yarn clean && yarn lint && yarn tsc && yarn build:esm && yarn build:umd",
         "build:esm": "rollup dist/index.js --file=dist/index.mjs --format esm --silent",
         "build:umd": "rollup dist/index.js --file=dist/index.umd.js --format umd --name=DndAction --silent",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
         "build:umd": "rollup dist/index.js --file=dist/index.umd.js --format umd --name=DndAction --silent",
         "prepublishOnly": "yarn build"
     },
-    "dependencies": {},
+    "dependencies": {
+        "csstype": "^3.1.0"
+    },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
         "@typescript-eslint/parser": "^5.12.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "test": "cypress run",
         "lint": "eslint .",
         "format": "prettier --write .",
-        "build": "yarn lint && yarn tsc",
+        "clean": "rm -r ./dist",
+        "build": "yarn clean && yarn lint && yarn tsc && yarn build:esm && yarn build:umd",
         "build:esm": "rollup dist/index.js --file=dist/index.mjs --format esm --silent",
         "build:umd": "rollup dist/index.js --file=dist/index.umd.js --format umd --name=DndAction --silent",
         "prepublishOnly": "yarn build"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.19",
+    "version": "0.9.20-test",
     "publishConfig": {
         "registry": "https://npm.pkg.github.com"
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "dist"
     ],
     "description": "*An awesome drag and drop library for Svelte 3 (not using the browser's built-in dnd, thanks god): Rich animations, nested containers, touch support and more *",
-    "version": "0.9.20-test",
+    "version": "0.9.20-test.2",
     "publishConfig": {
         "registry": "https://npm.pkg.github.com"
     },

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,7 +2,7 @@ import {dndzone as pointerDndZone} from "./pointerAction";
 import {dndzone as keyboardDndZone} from "./keyboardAction";
 import {ITEM_ID_KEY} from "./constants";
 import {toString} from "./helpers/util";
-import { Options } from './types';
+import {Options} from "./types";
 
 /**
  * A custom action to turn any container to a dnd zone and all of its direct children to draggables

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+import {Options} from "./types";
+import {InternalConfig} from "./internalTypes";
+
+const DEFAULT_DROP_ZONE_TYPE = "--any--";
+const DEFAULT_DROP_TARGET_STYLE = {
+    outline: "rgba(255, 255, 102, 0.7) solid 2px"
+};
+
+export function getInternalConfig(options: Options): InternalConfig {
+    return {
+        items: [...options.items],
+        flipDurationMs: options.flipDurationMs ?? 0,
+        dropAnimationDurationMs: options.flipDurationMs ?? 0,
+        type: options.type ?? DEFAULT_DROP_ZONE_TYPE,
+        dragDisabled: options.dragDisabled ?? false,
+        morphDisabled: options.morphDisabled ?? false,
+        dropFromOthersDisabled: options.dropFromOthersDisabled ?? false,
+        dropTargetStyle: options.dropTargetStyle ?? DEFAULT_DROP_TARGET_STYLE,
+        dropTargetClasses: options.dropTargetClasses ?? [],
+        transformDraggedElement: options.transformDraggedElement ?? (() => {}),
+        centreDraggedOnCursor: options.centreDraggedOnCursor ?? false
+    };
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,7 +59,7 @@ export const isOnServer = typeof window === "undefined";
 type LogFunction = (...data: unknown[]) => void;
 
 interface PrintDebug {
-    (generateMessage: () => unknown[], logFunction?: LogFunction): void;
+    (generateMessage: () => unknown | unknown[], logFunction?: LogFunction): void;
 }
 
 export let printDebug: PrintDebug = () => {};

--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -1,13 +1,13 @@
-import { DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent } from './internalTypes';
+import {DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent} from "./internalTypes";
 
 declare global {
-  interface HTMLElementEventMap {
-    draggedEntered: DraggedEnteredEvent;
-    draggedLeft: DraggedLeftEvent;
-    draggedOverIndex: DraggedOverIndexEvent;
-  }
+    interface HTMLElementEventMap {
+        draggedEntered: DraggedEnteredEvent;
+        draggedLeft: DraggedLeftEvent;
+        draggedOverIndex: DraggedOverIndexEvent;
+    }
 
-  interface WindowEventMap {
-    draggedLeftDocument: DraggedLeftDocumentEvent;
-  }
+    interface WindowEventMap {
+        draggedLeftDocument: DraggedLeftDocumentEvent;
+    }
 }

--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -1,0 +1,13 @@
+import { DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent } from './internalTypes';
+
+declare global {
+  interface HTMLElementEventMap {
+    'draggedEntered': DraggedEnteredEvent;
+    'draggedLeft': DraggedLeftEvent;
+    'draggedOverIndex': DraggedOverIndexEvent;
+  }
+
+  interface WindowEventMap {
+    'draggedLeftDocument': DraggedLeftDocumentEvent;
+  }
+}

--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -1,10 +1,12 @@
-import {DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent} from "./internalTypes";
+import {ConsiderEvent, DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent, FinalizeEvent} from "./internalTypes";
 
 declare global {
     interface HTMLElementEventMap {
         draggedEntered: DraggedEnteredEvent;
         draggedLeft: DraggedLeftEvent;
         draggedOverIndex: DraggedOverIndexEvent;
+        finalize: FinalizeEvent;
+        consider: ConsiderEvent;
     }
 
     interface WindowEventMap {

--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -2,12 +2,12 @@ import { DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, Dragge
 
 declare global {
   interface HTMLElementEventMap {
-    'draggedEntered': DraggedEnteredEvent;
-    'draggedLeft': DraggedLeftEvent;
-    'draggedOverIndex': DraggedOverIndexEvent;
+    draggedEntered: DraggedEnteredEvent;
+    draggedLeft: DraggedLeftEvent;
+    draggedOverIndex: DraggedOverIndexEvent;
   }
 
   interface WindowEventMap {
-    'draggedLeftDocument': DraggedLeftDocumentEvent;
+    draggedLeftDocument: DraggedLeftDocumentEvent;
   }
 }

--- a/src/dom.d.ts
+++ b/src/dom.d.ts
@@ -1,12 +1,10 @@
-import {ConsiderEvent, DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent, FinalizeEvent} from "./internalTypes";
+import {DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent} from "./internalTypes";
 
 declare global {
     interface HTMLElementEventMap {
         draggedEntered: DraggedEnteredEvent;
         draggedLeft: DraggedLeftEvent;
         draggedOverIndex: DraggedOverIndexEvent;
-        finalize: FinalizeEvent;
-        consider: ConsiderEvent;
     }
 
     interface WindowEventMap {

--- a/src/helpers/aria.ts
+++ b/src/helpers/aria.ts
@@ -10,7 +10,7 @@ const ID_TO_INSTRUCTION = {
 };
 
 const ALERT_DIV_ID = "dnd-action-aria-alert";
-let alertsDiv;
+let alertsDiv: HTMLDivElement;
 
 function initAriaOnBrowser() {
     // setting the dynamic alerts
@@ -47,7 +47,7 @@ export function initAria() {
     }
     return {...INSTRUCTION_IDs};
 }
-function instructionToHiddenDiv(id, txt) {
+function instructionToHiddenDiv(id: string, txt: string) {
     const div = document.createElement("div");
     div.id = id;
     div.innerHTML = `<p>${txt}</p>`;
@@ -61,7 +61,7 @@ function instructionToHiddenDiv(id, txt) {
  * Will make the screen reader alert the provided text to the user
  * @param {string} txt
  */
-export function alertToScreenReader(txt) {
+export function alertToScreenReader(txt: string) {
     alertsDiv.innerHTML = "";
     const alertText = document.createTextNode(txt);
     alertsDiv.appendChild(alertText);

--- a/src/helpers/dispatcher.ts
+++ b/src/helpers/dispatcher.ts
@@ -1,4 +1,4 @@
-import { IndexObj } from '../internalTypes';
+import { DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent, IndexObj } from '../internalTypes';
 import {DndEventInfo, Item} from "../types";
 
 // external events
@@ -45,14 +45,14 @@ export const DRAGGED_LEFT_DOCUMENT_EVENT_NAME = "draggedLeftDocument";
 export const DRAGGED_LEFT_TYPES = {
     LEFT_FOR_ANOTHER: "leftForAnother",
     OUTSIDE_OF_ANY: "outsideOfAny"
-};
+} as const;
 
 export function dispatchDraggedElementEnteredContainer(containerEl: Node, indexObj: IndexObj, draggedEl: Node) {
-    containerEl.dispatchEvent(
-        new CustomEvent(DRAGGED_ENTERED_EVENT_NAME, {
-            detail: {indexObj, draggedEl}
-        })
-    );
+    const event: DraggedEnteredEvent = new CustomEvent(DRAGGED_ENTERED_EVENT_NAME, {
+      detail: { indexObj, draggedEl }
+    });
+
+    containerEl.dispatchEvent(event);
 }
 
 /**
@@ -61,31 +61,32 @@ export function dispatchDraggedElementEnteredContainer(containerEl: Node, indexO
  * @param theOtherDz - the new dropzone the element entered
  */
 export function dispatchDraggedElementLeftContainerForAnother(containerEl: Node, draggedEl: Node, theOtherDz: Node) {
-    containerEl.dispatchEvent(
-        new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
-            detail: {draggedEl, type: DRAGGED_LEFT_TYPES.LEFT_FOR_ANOTHER, theOtherDz}
-        })
-    );
+  const event: DraggedLeftEvent = new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
+    detail: { draggedEl, type: DRAGGED_LEFT_TYPES.LEFT_FOR_ANOTHER, theOtherDz }
+  });
+
+  containerEl.dispatchEvent(event);
 }
 
 export function dispatchDraggedElementLeftContainerForNone(containerEl: Node, draggedEl: Node) {
-    containerEl.dispatchEvent(
-        new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
-            detail: {draggedEl, type: DRAGGED_LEFT_TYPES.OUTSIDE_OF_ANY}
-        })
-    );
+  const event: DraggedLeftEvent = new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
+    detail: { draggedEl, type: DRAGGED_LEFT_TYPES.OUTSIDE_OF_ANY }
+  });
+
+  containerEl.dispatchEvent(event);
 }
+
 export function dispatchDraggedElementIsOverIndex(containerEl: Node, indexObj: IndexObj, draggedEl: Node) {
-    containerEl.dispatchEvent(
-        new CustomEvent(DRAGGED_OVER_INDEX_EVENT_NAME, {
-            detail: {indexObj, draggedEl}
-        })
-    );
+  const event: DraggedOverIndexEvent = new CustomEvent(DRAGGED_OVER_INDEX_EVENT_NAME, {
+    detail: {indexObj, draggedEl}
+  });
+
+  containerEl.dispatchEvent(event);
 }
 export function dispatchDraggedLeftDocument(draggedEl: Node) {
-    window.dispatchEvent(
-        new CustomEvent(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, {
-            detail: {draggedEl}
-        })
-    );
+  const event: DraggedLeftDocumentEvent = new CustomEvent(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, {
+    detail: {draggedEl}
+  });
+  
+  window.dispatchEvent(event);
 }

--- a/src/helpers/dispatcher.ts
+++ b/src/helpers/dispatcher.ts
@@ -1,3 +1,6 @@
+import { IndexObj } from '../internalTypes';
+import {DndEventInfo, Item} from "../types";
+
 // external events
 const FINALIZE_EVENT_NAME = "finalize";
 const CONSIDER_EVENT_NAME = "consider";
@@ -11,7 +14,7 @@ const CONSIDER_EVENT_NAME = "consider";
  * @param {Array} items
  * @param {Info} info
  */
-export function dispatchFinalizeEvent(el, items, info) {
+export function dispatchFinalizeEvent(el: Node, items: Item[], info: DndEventInfo) {
     el.dispatchEvent(
         new CustomEvent(FINALIZE_EVENT_NAME, {
             detail: {items, info}
@@ -25,7 +28,7 @@ export function dispatchFinalizeEvent(el, items, info) {
  * @param {Array} items
  * @param {Info} info
  */
-export function dispatchConsiderEvent(el, items, info) {
+export function dispatchConsiderEvent(el: Node, items: Item[], info: DndEventInfo) {
     el.dispatchEvent(
         new CustomEvent(CONSIDER_EVENT_NAME, {
             detail: {items, info}
@@ -44,7 +47,7 @@ export const DRAGGED_LEFT_TYPES = {
     OUTSIDE_OF_ANY: "outsideOfAny"
 };
 
-export function dispatchDraggedElementEnteredContainer(containerEl, indexObj, draggedEl) {
+export function dispatchDraggedElementEnteredContainer(containerEl: Node, indexObj: IndexObj, draggedEl: Node) {
     containerEl.dispatchEvent(
         new CustomEvent(DRAGGED_ENTERED_EVENT_NAME, {
             detail: {indexObj, draggedEl}
@@ -57,7 +60,7 @@ export function dispatchDraggedElementEnteredContainer(containerEl, indexObj, dr
  * @param draggedEl - the dragged element
  * @param theOtherDz - the new dropzone the element entered
  */
-export function dispatchDraggedElementLeftContainerForAnother(containerEl, draggedEl, theOtherDz) {
+export function dispatchDraggedElementLeftContainerForAnother(containerEl: Node, draggedEl: Node, theOtherDz: Node) {
     containerEl.dispatchEvent(
         new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
             detail: {draggedEl, type: DRAGGED_LEFT_TYPES.LEFT_FOR_ANOTHER, theOtherDz}
@@ -65,21 +68,21 @@ export function dispatchDraggedElementLeftContainerForAnother(containerEl, dragg
     );
 }
 
-export function dispatchDraggedElementLeftContainerForNone(containerEl, draggedEl) {
+export function dispatchDraggedElementLeftContainerForNone(containerEl: Node, draggedEl: Node) {
     containerEl.dispatchEvent(
         new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
             detail: {draggedEl, type: DRAGGED_LEFT_TYPES.OUTSIDE_OF_ANY}
         })
     );
 }
-export function dispatchDraggedElementIsOverIndex(containerEl, indexObj, draggedEl) {
+export function dispatchDraggedElementIsOverIndex(containerEl: Node, indexObj: IndexObj, draggedEl: Node) {
     containerEl.dispatchEvent(
         new CustomEvent(DRAGGED_OVER_INDEX_EVENT_NAME, {
             detail: {indexObj, draggedEl}
         })
     );
 }
-export function dispatchDraggedLeftDocument(draggedEl) {
+export function dispatchDraggedLeftDocument(draggedEl: Node) {
     window.dispatchEvent(
         new CustomEvent(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, {
             detail: {draggedEl}

--- a/src/helpers/dispatcher.ts
+++ b/src/helpers/dispatcher.ts
@@ -1,4 +1,12 @@
-import {DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent, IndexObj} from "../internalTypes";
+import {
+    ConsiderEvent,
+    DraggedEnteredEvent,
+    DraggedLeftDocumentEvent,
+    DraggedLeftEvent,
+    DraggedOverIndexEvent,
+    FinalizeEvent,
+    IndexObj
+} from "../internalTypes";
 import {DndEventInfo, Item} from "../types";
 
 // external events
@@ -15,11 +23,10 @@ const CONSIDER_EVENT_NAME = "consider";
  * @param {Info} info
  */
 export function dispatchFinalizeEvent(el: Node, items: Item[], info: DndEventInfo) {
-    el.dispatchEvent(
-        new CustomEvent(FINALIZE_EVENT_NAME, {
-            detail: {items, info}
-        })
-    );
+    const event: FinalizeEvent = new CustomEvent(FINALIZE_EVENT_NAME, {
+        detail: {items, info}
+    });
+    el.dispatchEvent(event);
 }
 
 /**
@@ -29,11 +36,10 @@ export function dispatchFinalizeEvent(el: Node, items: Item[], info: DndEventInf
  * @param {Info} info
  */
 export function dispatchConsiderEvent(el: Node, items: Item[], info: DndEventInfo) {
-    el.dispatchEvent(
-        new CustomEvent(CONSIDER_EVENT_NAME, {
-            detail: {items, info}
-        })
-    );
+    const event: ConsiderEvent = new CustomEvent(CONSIDER_EVENT_NAME, {
+        detail: {items, info}
+    });
+    el.dispatchEvent(event);
 }
 
 // internal events

--- a/src/helpers/dispatcher.ts
+++ b/src/helpers/dispatcher.ts
@@ -1,4 +1,4 @@
-import { DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent, IndexObj } from '../internalTypes';
+import {DraggedEnteredEvent, DraggedLeftDocumentEvent, DraggedLeftEvent, DraggedOverIndexEvent, IndexObj} from "../internalTypes";
 import {DndEventInfo, Item} from "../types";
 
 // external events
@@ -49,7 +49,7 @@ export const DRAGGED_LEFT_TYPES = {
 
 export function dispatchDraggedElementEnteredContainer(containerEl: Node, indexObj: IndexObj, draggedEl: Node) {
     const event: DraggedEnteredEvent = new CustomEvent(DRAGGED_ENTERED_EVENT_NAME, {
-      detail: { indexObj, draggedEl }
+        detail: {indexObj, draggedEl}
     });
 
     containerEl.dispatchEvent(event);
@@ -61,32 +61,32 @@ export function dispatchDraggedElementEnteredContainer(containerEl: Node, indexO
  * @param theOtherDz - the new dropzone the element entered
  */
 export function dispatchDraggedElementLeftContainerForAnother(containerEl: Node, draggedEl: Node, theOtherDz: Node) {
-  const event: DraggedLeftEvent = new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
-    detail: { draggedEl, type: DRAGGED_LEFT_TYPES.LEFT_FOR_ANOTHER, theOtherDz }
-  });
+    const event: DraggedLeftEvent = new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
+        detail: {draggedEl, type: DRAGGED_LEFT_TYPES.LEFT_FOR_ANOTHER, theOtherDz}
+    });
 
-  containerEl.dispatchEvent(event);
+    containerEl.dispatchEvent(event);
 }
 
 export function dispatchDraggedElementLeftContainerForNone(containerEl: Node, draggedEl: Node) {
-  const event: DraggedLeftEvent = new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
-    detail: { draggedEl, type: DRAGGED_LEFT_TYPES.OUTSIDE_OF_ANY }
-  });
+    const event: DraggedLeftEvent = new CustomEvent(DRAGGED_LEFT_EVENT_NAME, {
+        detail: {draggedEl, type: DRAGGED_LEFT_TYPES.OUTSIDE_OF_ANY}
+    });
 
-  containerEl.dispatchEvent(event);
+    containerEl.dispatchEvent(event);
 }
 
 export function dispatchDraggedElementIsOverIndex(containerEl: Node, indexObj: IndexObj, draggedEl: Node) {
-  const event: DraggedOverIndexEvent = new CustomEvent(DRAGGED_OVER_INDEX_EVENT_NAME, {
-    detail: {indexObj, draggedEl}
-  });
+    const event: DraggedOverIndexEvent = new CustomEvent(DRAGGED_OVER_INDEX_EVENT_NAME, {
+        detail: {indexObj, draggedEl}
+    });
 
-  containerEl.dispatchEvent(event);
+    containerEl.dispatchEvent(event);
 }
 export function dispatchDraggedLeftDocument(draggedEl: Node) {
-  const event: DraggedLeftDocumentEvent = new CustomEvent(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, {
-    detail: {draggedEl}
-  });
-  
-  window.dispatchEvent(event);
+    const event: DraggedLeftDocumentEvent = new CustomEvent(DRAGGED_LEFT_DOCUMENT_EVENT_NAME, {
+        detail: {draggedEl}
+    });
+
+    window.dispatchEvent(event);
 }

--- a/src/helpers/intersection.ts
+++ b/src/helpers/intersection.ts
@@ -9,8 +9,6 @@ import {Point, AbsoluteRect} from "../internalTypes";
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
 export function getBoundingRectNoTransforms(el: HTMLElement): AbsoluteRect {
-    let ta: string[];
-
     const rect = el.getBoundingClientRect();
     const style = getComputedStyle(el);
     const tx = style.transform;
@@ -18,13 +16,13 @@ export function getBoundingRectNoTransforms(el: HTMLElement): AbsoluteRect {
     if (tx) {
         let sx: number, sy: number, dx: number, dy: number;
         if (tx.startsWith("matrix3d(")) {
-            ta = tx.slice(9, -1).split(/, /);
+            const ta = tx.slice(9, -1).split(/, /);
             sx = +ta[0];
             sy = +ta[5];
             dx = +ta[12];
             dy = +ta[13];
         } else if (tx.startsWith("matrix(")) {
-            ta = tx.slice(7, -1).split(/, /);
+            const ta = tx.slice(7, -1).split(/, /);
             sx = +ta[0];
             sy = +ta[3];
             dx = +ta[4];

--- a/src/helpers/intersection.ts
+++ b/src/helpers/intersection.ts
@@ -6,7 +6,7 @@
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
 
-import { Point } from '../internalTypes';
+import {Point} from "../internalTypes";
 
 export function getBoundingRectNoTransforms(el: HTMLElement): DOMRect {
     let ta: string[];

--- a/src/helpers/intersection.ts
+++ b/src/helpers/intersection.ts
@@ -5,56 +5,73 @@
  * @param {HTMLElement} el
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
-export function getBoundingRectNoTransforms(el) {
-    let ta;
+
+import { Point } from '../internalTypes';
+
+export function getBoundingRectNoTransforms(el: HTMLElement): DOMRect {
+    let ta: string[];
+
     const rect = el.getBoundingClientRect();
     const style = getComputedStyle(el);
     const tx = style.transform;
 
-    if (tx) {
-        let sx, sy, dx, dy;
-        if (tx.startsWith("matrix3d(")) {
-            ta = tx.slice(9, -1).split(/, /);
-            sx = +ta[0];
-            sy = +ta[5];
-            dx = +ta[12];
-            dy = +ta[13];
-        } else if (tx.startsWith("matrix(")) {
-            ta = tx.slice(7, -1).split(/, /);
-            sx = +ta[0];
-            sy = +ta[3];
-            dx = +ta[4];
-            dy = +ta[5];
-        } else {
-            return rect;
-        }
+    if (!tx) {
+        return rect;
+    }
 
-        const to = style.transformOrigin;
-        const x = rect.x - dx - (1 - sx) * parseFloat(to);
-        const y = rect.y - dy - (1 - sy) * parseFloat(to.slice(to.indexOf(" ") + 1));
-        const w = sx ? rect.width / sx : el.offsetWidth;
-        const h = sy ? rect.height / sy : el.offsetHeight;
-        return {
-            x: x,
-            y: y,
-            width: w,
-            height: h,
-            top: y,
-            right: x + w,
-            bottom: y + h,
-            left: x
-        };
+    let sx: number, sy: number, dx: number, dy: number;
+    if (tx.startsWith("matrix3d(")) {
+        ta = tx.slice(9, -1).split(/, /);
+        sx = +ta[0];
+        sy = +ta[5];
+        dx = +ta[12];
+        dy = +ta[13];
+    } else if (tx.startsWith("matrix(")) {
+        ta = tx.slice(7, -1).split(/, /);
+        sx = +ta[0];
+        sy = +ta[3];
+        dx = +ta[4];
+        dy = +ta[5];
     } else {
         return rect;
     }
+
+    const to = style.transformOrigin;
+    const x = rect.x - dx - (1 - sx) * parseFloat(to);
+    const y = rect.y - dy - (1 - sy) * parseFloat(to.slice(to.indexOf(" ") + 1));
+    const w = sx ? rect.width / sx : el.offsetWidth;
+    const h = sy ? rect.height / sy : el.offsetHeight;
+
+    const newRect: Omit<DOMRect, "toJSON"> = {
+        x: x,
+        y: y,
+        width: w,
+        height: h,
+        top: y,
+        right: x + w,
+        bottom: y + h,
+        left: x
+    };
+
+    return {
+        ...newRect,
+        toJSON: () => JSON.stringify(newRect)
+    };
 }
+
+export type AbsoluteRect = {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+};
 
 /**
  * Gets the absolute bounding rect (accounts for the window's scroll position and removes transforms)
  * @param {HTMLElement} el
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
-export function getAbsoluteRectNoTransforms(el) {
+export function getAbsoluteRectNoTransforms(el: HTMLElement): AbsoluteRect {
     const rect = getBoundingRectNoTransforms(el);
     return {
         top: rect.top + window.scrollY,
@@ -69,7 +86,7 @@ export function getAbsoluteRectNoTransforms(el) {
  * @param {HTMLElement} el
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
-export function getAbsoluteRect(el) {
+export function getAbsoluteRect(el: HTMLElement): AbsoluteRect {
     const rect = el.getBoundingClientRect();
     return {
         top: rect.top + window.scrollY,
@@ -79,80 +96,41 @@ export function getAbsoluteRect(el) {
     };
 }
 
-/**
- * finds the center :)
- * @typedef {Object} Rect
- * @property {number} top
- * @property {number} bottom
- * @property {number} left
- * @property {number} right
- * @param {Rect} rect
- * @return {{x: number, y: number}}
- */
-export function findCenter(rect) {
+/** finds the center :) */
+export function findCenter(rect: AbsoluteRect): Point {
     return {
         x: (rect.left + rect.right) / 2,
         y: (rect.top + rect.bottom) / 2
     };
 }
 
-/**
- * @typedef {Object} Point
- * @property {number} x
- * @property {number} y
- * @param {Point} pointA
- * @param {Point} pointB
- * @return {number}
- */
-function calcDistance(pointA, pointB) {
+function calcDistance(pointA: Point, pointB: Point): number {
     return Math.sqrt(Math.pow(pointA.x - pointB.x, 2) + Math.pow(pointA.y - pointB.y, 2));
 }
 
-/**
- * @param {Point} point
- * @param {Rect} rect
- * @return {boolean|boolean}
- */
-export function isPointInsideRect(point, rect) {
+export function isPointInsideRect(point: Point, rect: AbsoluteRect): boolean {
     return point.y <= rect.bottom && point.y >= rect.top && point.x >= rect.left && point.x <= rect.right;
 }
 
-/**
- * find the absolute coordinates of the center of a dom element
- * @param el {HTMLElement}
- * @returns {{x: number, y: number}}
- */
-export function findCenterOfElement(el) {
+/** find the absolute coordinates of the center of a dom element */
+export function findCenterOfElement(el: HTMLElement): Point {
     return findCenter(getAbsoluteRect(el));
 }
 
-/**
- * @param {HTMLElement} elA
- * @param {HTMLElement} elB
- * @return {boolean}
- */
-export function isCenterOfAInsideB(elA, elB) {
+export function isCenterOfAInsideB(elA: HTMLElement, elB: HTMLElement): boolean {
     const centerOfA = findCenterOfElement(elA);
     const rectOfB = getAbsoluteRectNoTransforms(elB);
     return isPointInsideRect(centerOfA, rectOfB);
 }
 
-/**
- * @param {HTMLElement|ChildNode} elA
- * @param {HTMLElement|ChildNode} elB
- * @return {number}
- */
-export function calcDistanceBetweenCenters(elA, elB) {
+export function calcDistanceBetweenCenters(elA: HTMLElement, elB: HTMLElement): number {
     const centerOfA = findCenterOfElement(elA);
     const centerOfB = findCenterOfElement(elB);
     return calcDistance(centerOfA, centerOfB);
 }
 
-/**
- * @param {HTMLElement} el - the element to check
- * @returns {boolean} - true if the element in its entirety is off screen including the scrollable area (the normal dom events look at the mouse rather than the element)
- */
-export function isElementOffDocument(el) {
+/** returns true if the leement in its entirety is off screen including the scrollable area (the normal dom events look at the mouse rather than the element) */
+export function isElementOffDocument(el: HTMLElement): boolean {
     const rect = getAbsoluteRect(el);
     return rect.right < 0 || rect.left > document.documentElement.scrollWidth || rect.bottom < 0 || rect.top > document.documentElement.scrollHeight;
 }
@@ -163,11 +141,12 @@ export function isElementOffDocument(el) {
  * @param {HTMLElement} el
  * @return {null|{top: number, left: number, bottom: number, right: number}}
  */
-export function calcInnerDistancesBetweenPointAndSidesOfElement(point, el) {
+export function calcInnerDistancesBetweenPointAndSidesOfElement(point: Point, el: HTMLElement): AbsoluteRect | null {
     const rect = getAbsoluteRect(el);
     if (!isPointInsideRect(point, rect)) {
         return null;
     }
+
     return {
         top: point.y - rect.top,
         bottom: rect.bottom - point.y,

--- a/src/helpers/intersection.ts
+++ b/src/helpers/intersection.ts
@@ -6,65 +6,53 @@
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
 
-import {Point} from "../internalTypes";
+import {Point, AbsoluteRect, Rect} from "../internalTypes";
 
-export function getBoundingRectNoTransforms(el: HTMLElement): DOMRect {
+export function getBoundingRectNoTransforms(el: HTMLElement): Rect {
     let ta: string[];
 
     const rect = el.getBoundingClientRect();
     const style = getComputedStyle(el);
     const tx = style.transform;
 
-    if (!tx) {
-        return rect;
-    }
+    if (tx) {
+        let sx: number, sy: number, dx: number, dy: number;
+        if (tx.startsWith("matrix3d(")) {
+            ta = tx.slice(9, -1).split(/, /);
+            sx = +ta[0];
+            sy = +ta[5];
+            dx = +ta[12];
+            dy = +ta[13];
+        } else if (tx.startsWith("matrix(")) {
+            ta = tx.slice(7, -1).split(/, /);
+            sx = +ta[0];
+            sy = +ta[3];
+            dx = +ta[4];
+            dy = +ta[5];
+        } else {
+            return rect;
+        }
 
-    let sx: number, sy: number, dx: number, dy: number;
-    if (tx.startsWith("matrix3d(")) {
-        ta = tx.slice(9, -1).split(/, /);
-        sx = +ta[0];
-        sy = +ta[5];
-        dx = +ta[12];
-        dy = +ta[13];
-    } else if (tx.startsWith("matrix(")) {
-        ta = tx.slice(7, -1).split(/, /);
-        sx = +ta[0];
-        sy = +ta[3];
-        dx = +ta[4];
-        dy = +ta[5];
+        const to = style.transformOrigin;
+        const x = rect.x - dx - (1 - sx) * parseFloat(to);
+        const y = rect.y - dy - (1 - sy) * parseFloat(to.slice(to.indexOf(" ") + 1));
+        const w = sx ? rect.width / sx : el.offsetWidth;
+        const h = sy ? rect.height / sy : el.offsetHeight;
+
+        return {
+            x: x,
+            y: y,
+            width: w,
+            height: h,
+            top: y,
+            right: x + w,
+            bottom: y + h,
+            left: x
+        };
     } else {
         return rect;
     }
-
-    const to = style.transformOrigin;
-    const x = rect.x - dx - (1 - sx) * parseFloat(to);
-    const y = rect.y - dy - (1 - sy) * parseFloat(to.slice(to.indexOf(" ") + 1));
-    const w = sx ? rect.width / sx : el.offsetWidth;
-    const h = sy ? rect.height / sy : el.offsetHeight;
-
-    const newRect: Omit<DOMRect, "toJSON"> = {
-        x: x,
-        y: y,
-        width: w,
-        height: h,
-        top: y,
-        right: x + w,
-        bottom: y + h,
-        left: x
-    };
-
-    return {
-        ...newRect,
-        toJSON: () => JSON.stringify(newRect)
-    };
 }
-
-export type AbsoluteRect = {
-    top: number;
-    bottom: number;
-    left: number;
-    right: number;
-};
 
 /**
  * Gets the absolute bounding rect (accounts for the window's scroll position and removes transforms)

--- a/src/helpers/intersection.ts
+++ b/src/helpers/intersection.ts
@@ -1,14 +1,14 @@
 // This is based off https://stackoverflow.com/questions/27745438/how-to-compute-getboundingclientrect-without-considering-transforms/57876601#57876601
 // It removes the transforms that are potentially applied by the flip animations
 
-import {Point, AbsoluteRect, Rect} from "../internalTypes";
+import {Point, AbsoluteRect} from "../internalTypes";
 
 /**
  * Gets the bounding rect but removes transforms (ex: flip animation)
  * @param {HTMLElement} el
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
-export function getBoundingRectNoTransforms(el: HTMLElement): Rect {
+export function getBoundingRectNoTransforms(el: HTMLElement): AbsoluteRect {
     let ta: string[];
 
     const rect = el.getBoundingClientRect();
@@ -40,10 +40,6 @@ export function getBoundingRectNoTransforms(el: HTMLElement): Rect {
         const h = sy ? rect.height / sy : el.offsetHeight;
 
         return {
-            x: x,
-            y: y,
-            width: w,
-            height: h,
             top: y,
             right: x + w,
             bottom: y + h,

--- a/src/helpers/intersection.ts
+++ b/src/helpers/intersection.ts
@@ -1,13 +1,13 @@
 // This is based off https://stackoverflow.com/questions/27745438/how-to-compute-getboundingclientrect-without-considering-transforms/57876601#57876601
 // It removes the transforms that are potentially applied by the flip animations
+
+import {Point, AbsoluteRect, Rect} from "../internalTypes";
+
 /**
  * Gets the bounding rect but removes transforms (ex: flip animation)
  * @param {HTMLElement} el
  * @return {{top: number, left: number, bottom: number, right: number}}
  */
-
-import {Point, AbsoluteRect, Rect} from "../internalTypes";
-
 export function getBoundingRectNoTransforms(el: HTMLElement): Rect {
     let ta: string[];
 

--- a/src/helpers/listUtil.ts
+++ b/src/helpers/listUtil.ts
@@ -1,13 +1,6 @@
-import {
-    isCenterOfAInsideB,
-    calcDistanceBetweenCenters,
-    getAbsoluteRectNoTransforms,
-    isPointInsideRect,
-    findCenterOfElement,
-    AbsoluteRect
-} from "./intersection";
+import {isCenterOfAInsideB, calcDistanceBetweenCenters, getAbsoluteRectNoTransforms, isPointInsideRect, findCenterOfElement} from "./intersection";
 import {printDebug, SHADOW_ELEMENT_ATTRIBUTE_NAME} from "../constants";
-import {IndexObj} from "../internalTypes";
+import {IndexObj, AbsoluteRect} from "../internalTypes";
 
 // map from the reference to the parent element, to the absolute rects of its child elements, by child index
 type Index = Map<Element, Map<number, AbsoluteRect>>;

--- a/src/helpers/listUtil.ts
+++ b/src/helpers/listUtil.ts
@@ -1,24 +1,37 @@
-import {isCenterOfAInsideB, calcDistanceBetweenCenters, getAbsoluteRectNoTransforms, isPointInsideRect, findCenterOfElement} from "./intersection";
+import {
+    isCenterOfAInsideB,
+    calcDistanceBetweenCenters,
+    getAbsoluteRectNoTransforms,
+    isPointInsideRect,
+    findCenterOfElement,
+    AbsoluteRect
+} from "./intersection";
 import {printDebug, SHADOW_ELEMENT_ATTRIBUTE_NAME} from "../constants";
+import {IndexObj} from "../internalTypes";
 
-let dzToShadowIndexToRect;
+// map from the reference to the parent element, to the absolute rects of its child elements, by child index
+type Index = Map<Element, Map<number, AbsoluteRect>>;
+
+let dzToShadowIndexToRect: Index;
 
 /**
  * Resets the cache that allows for smarter "would be index" resolution. Should be called after every drag operation
  */
-export function resetIndexesCache() {
+export function resetIndexesCache(): void {
     printDebug(() => "resetting indexes cache");
     dzToShadowIndexToRect = new Map();
 }
+
 resetIndexesCache();
 
 /**
  * Resets the cache that allows for smarter "would be index" resolution for a specific dropzone, should be called after the zone was scrolled
  * @param {HTMLElement} dz
  */
-export function resetIndexesCacheForDz(dz) {
+export function resetIndexesCacheForDz(dz: Element): void {
     printDebug(() => "resetting indexes cache for dz");
-    dzToShadowIndexToRect.delete(dz);
+
+    dzToShadowIndexToRect?.delete(dz);
 }
 
 /**
@@ -27,15 +40,34 @@ export function resetIndexesCacheForDz(dz) {
  * @param {HTMLElement} dz
  * @return {number} - the shadow element index
  */
-function cacheShadowRect(dz) {
+function cacheShadowRect(dz: HTMLElement): number | undefined {
     const shadowElIndex = Array.from(dz.children).findIndex(child => child.getAttribute(SHADOW_ELEMENT_ATTRIBUTE_NAME));
+
+    if (!dzToShadowIndexToRect) {
+        return undefined;
+    }
+
     if (shadowElIndex >= 0) {
         if (!dzToShadowIndexToRect.has(dz)) {
             dzToShadowIndexToRect.set(dz, new Map());
         }
-        dzToShadowIndexToRect.get(dz).set(shadowElIndex, getAbsoluteRectNoTransforms(dz.children[shadowElIndex]));
+
+        const dzCache = dzToShadowIndexToRect.get(dz);
+
+        // should never happen, just for type safety
+        if (!dzCache) {
+            return undefined;
+        }
+
+        const child = dz.children[shadowElIndex];
+
+        if (child instanceof HTMLElement) {
+            dzCache.set(shadowElIndex, getAbsoluteRectNoTransforms(child));
+        }
+
         return shadowElIndex;
     }
+
     return undefined;
 }
 
@@ -50,41 +82,61 @@ function cacheShadowRect(dz) {
  * @param {HTMLElement} collectionBelowEl
  * @returns {Index|null} -  if the element is over the container the Index object otherwise null
  */
-export function findWouldBeIndex(floatingAboveEl, collectionBelowEl) {
+export function findWouldBeIndex(floatingAboveEl: HTMLElement, collectionBelowEl: HTMLElement): IndexObj | null {
     if (!isCenterOfAInsideB(floatingAboveEl, collectionBelowEl)) {
         return null;
     }
+
     const children = collectionBelowEl.children;
+
     // the container is empty, floating element should be the first
     if (children.length === 0) {
         return {index: 0, isProximityBased: true};
     }
+
     const shadowElIndex = cacheShadowRect(collectionBelowEl);
 
     // the search could be more efficient but keeping it simple for now
     // a possible improvement: pass in the lastIndex it was found in and check there first, then expand from there
     for (let i = 0; i < children.length; i++) {
-        if (isCenterOfAInsideB(floatingAboveEl, children[i])) {
-            const cachedShadowRect = dzToShadowIndexToRect.has(collectionBelowEl) && dzToShadowIndexToRect.get(collectionBelowEl).get(i);
-            if (cachedShadowRect) {
-                if (!isPointInsideRect(findCenterOfElement(floatingAboveEl), cachedShadowRect)) {
+        const child = children[i];
+
+        if (!(child instanceof HTMLElement)) {
+            continue;
+        }
+
+        const isCenterInside = isCenterOfAInsideB(floatingAboveEl, child);
+
+        if (isCenterInside) {
+            const dzCache = dzToShadowIndexToRect.get(collectionBelowEl);
+
+            if (dzCache) {
+                const cachedShadowRect = dzCache.get(i);
+                if (cachedShadowRect && !isPointInsideRect(findCenterOfElement(floatingAboveEl), cachedShadowRect)) {
                     return {index: shadowElIndex, isProximityBased: false};
                 }
             }
+
             return {index: i, isProximityBased: false};
         }
     }
+
     // this can happen if there is space around the children so the floating element has
     //entered the container but not any of the children, in this case we will find the nearest child
     let minDistanceSoFar = Number.MAX_VALUE;
     let indexOfMin = undefined;
     // we are checking all of them because we don't know whether we are dealing with a horizontal or vertical container and where the floating element entered from
     for (let i = 0; i < children.length; i++) {
-        const distance = calcDistanceBetweenCenters(floatingAboveEl, children[i]);
-        if (distance < minDistanceSoFar) {
-            minDistanceSoFar = distance;
-            indexOfMin = i;
+        const child = children[i];
+
+        if (child instanceof HTMLElement) {
+            const distance = calcDistanceBetweenCenters(floatingAboveEl, child);
+            if (distance < minDistanceSoFar) {
+                minDistanceSoFar = distance;
+                indexOfMin = i;
+            }
         }
     }
+
     return {index: indexOfMin, isProximityBased: true};
 }

--- a/src/helpers/listUtil.ts
+++ b/src/helpers/listUtil.ts
@@ -3,7 +3,7 @@ import {printDebug, SHADOW_ELEMENT_ATTRIBUTE_NAME} from "../constants";
 import {IndexObj, AbsoluteRect} from "../internalTypes";
 
 // map from the reference to the parent element, to the absolute rects of its child elements, by child index
-type Index = Map<Element, Map<number, AbsoluteRect>>;
+type Index = Map<HTMLElement, Map<number, AbsoluteRect>>;
 
 let dzToShadowIndexToRect: Index;
 
@@ -21,7 +21,7 @@ resetIndexesCache();
  * Resets the cache that allows for smarter "would be index" resolution for a specific dropzone, should be called after the zone was scrolled
  * @param {HTMLElement} dz
  */
-export function resetIndexesCacheForDz(dz: Element): void {
+export function resetIndexesCacheForDz(dz: HTMLElement): void {
     printDebug(() => "resetting indexes cache for dz");
 
     dzToShadowIndexToRect?.delete(dz);

--- a/src/helpers/listUtil.ts
+++ b/src/helpers/listUtil.ts
@@ -122,12 +122,14 @@ export function findWouldBeIndex(floatingAboveEl: HTMLElement, collectionBelowEl
     for (let i = 0; i < children.length; i++) {
         const child = children[i];
 
-        if (child instanceof HTMLElement) {
-            const distance = calcDistanceBetweenCenters(floatingAboveEl, child);
-            if (distance < minDistanceSoFar) {
-                minDistanceSoFar = distance;
-                indexOfMin = i;
-            }
+        if (!(child instanceof HTMLElement)) {
+            continue;
+        }
+
+        const distance = calcDistanceBetweenCenters(floatingAboveEl, child);
+        if (distance < minDistanceSoFar) {
+            minDistanceSoFar = distance;
+            indexOfMin = i;
         }
     }
 

--- a/src/helpers/observer.ts
+++ b/src/helpers/observer.ts
@@ -38,11 +38,7 @@ export function observe(draggedEl: HTMLElement, dropZones: Set<HTMLElement>, int
     function andNow() {
         const currentCenterOfDragged = findCenterOfElement(draggedEl);
 
-        let scrolled = false;
-
-        if (lastDropZoneFound) {
-            scrolled = scrollIfNeeded(currentCenterOfDragged, lastDropZoneFound);
-        }
+        const scrolled = scrollIfNeeded(currentCenterOfDragged, lastDropZoneFound);
 
         // we only want to make a new decision after the element was moved a bit to prevent flickering
         if (

--- a/src/helpers/point.ts
+++ b/src/helpers/point.ts
@@ -1,0 +1,9 @@
+import {Point} from "../internalTypes";
+
+export function getPointFromEvent(e: MouseEvent | TouchEvent): Point {
+    if ("touches" in e) {
+        return {x: e.touches[0].clientX, y: e.touches[0].clientY};
+    } else {
+        return {x: e.clientX, y: e.clientY};
+    }
+}

--- a/src/helpers/scroller.ts
+++ b/src/helpers/scroller.ts
@@ -2,15 +2,17 @@ import {calcInnerDistancesBetweenPointAndSidesOfElement} from "./intersection";
 const SCROLL_ZONE_PX = 25;
 
 type ScrollingInfo = {
-    directionObj: undefined | {
-        x: number;
-        y: number;
-    };
+    directionObj:
+        | undefined
+        | {
+              x: number;
+              y: number;
+          };
     stepPx: number;
 };
 
 interface Scroller {
-    scrollIfNeeded(pointer: { x: number; y: number }, elementToScroll: HTMLElement): boolean;
+    scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement): boolean;
     resetScrolling(): void;
 }
 
@@ -41,7 +43,7 @@ export function makeScroller(): Scroller {
      * Can be called repeatedly with updated pointer and elementToScroll values without issues
      * @return {boolean} - true if scrolling was needed
      */
-    function scrollIfNeeded(pointer: { x: number; y: number }, elementToScroll: HTMLElement): boolean {
+    function scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement): boolean {
         if (!elementToScroll) {
             return false;
         }

--- a/src/helpers/scroller.ts
+++ b/src/helpers/scroller.ts
@@ -1,18 +1,14 @@
 import {calcInnerDistancesBetweenPointAndSidesOfElement} from "./intersection";
+import {Point} from "../internalTypes";
 const SCROLL_ZONE_PX = 25;
 
 type ScrollingInfo = {
-    directionObj:
-        | undefined
-        | {
-              x: number;
-              y: number;
-          };
+    directionObj: Point | undefined;
     stepPx: number;
 };
 
 interface Scroller {
-    scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement | undefined): boolean;
+    scrollIfNeeded(pointer: Point, elementToScroll: HTMLElement | undefined): boolean;
     resetScrolling(): void;
 }
 
@@ -43,7 +39,7 @@ export function makeScroller(): Scroller {
      * Can be called repeatedly with updated pointer and elementToScroll values without issues
      * @return {boolean} - true if scrolling was needed
      */
-    function scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement | undefined): boolean {
+    function scrollIfNeeded(pointer: Point, elementToScroll: HTMLElement | undefined): boolean {
         if (!elementToScroll) {
             return false;
         }

--- a/src/helpers/scroller.ts
+++ b/src/helpers/scroller.ts
@@ -1,21 +1,38 @@
 import {calcInnerDistancesBetweenPointAndSidesOfElement} from "./intersection";
 const SCROLL_ZONE_PX = 25;
 
-export function makeScroller() {
-    let scrollingInfo;
+type ScrollingInfo = {
+    directionObj: undefined | {
+        x: number;
+        y: number;
+    };
+    stepPx: number;
+};
+
+interface Scroller {
+    scrollIfNeeded(pointer: { x: number; y: number }, elementToScroll: HTMLElement): boolean;
+    resetScrolling(): void;
+}
+
+export function makeScroller(): Scroller {
+    let scrollingInfo: ScrollingInfo;
+
     function resetScrolling() {
         scrollingInfo = {directionObj: undefined, stepPx: 0};
     }
+
     resetScrolling();
     // directionObj {x: 0|1|-1, y:0|1|-1} - 1 means down in y and right in x
-    function scrollContainer(containerEl) {
+    function scrollContainer(containerEl: HTMLElement) {
         const {directionObj, stepPx} = scrollingInfo;
+
         if (directionObj) {
             containerEl.scrollBy(directionObj.x * stepPx, directionObj.y * stepPx);
             window.requestAnimationFrame(() => scrollContainer(containerEl));
         }
     }
-    function calcScrollStepPx(distancePx) {
+
+    function calcScrollStepPx(distancePx: number): number {
         return SCROLL_ZONE_PX - distancePx;
     }
 
@@ -24,17 +41,20 @@ export function makeScroller() {
      * Can be called repeatedly with updated pointer and elementToScroll values without issues
      * @return {boolean} - true if scrolling was needed
      */
-    function scrollIfNeeded(pointer, elementToScroll) {
+    function scrollIfNeeded(pointer: { x: number; y: number }, elementToScroll: HTMLElement): boolean {
         if (!elementToScroll) {
             return false;
         }
+
         const distances = calcInnerDistancesBetweenPointAndSidesOfElement(pointer, elementToScroll);
         if (distances === null) {
             resetScrolling();
             return false;
         }
+
         const isAlreadyScrolling = !!scrollingInfo.directionObj;
         let [scrollingVertically, scrollingHorizontally] = [false, false];
+
         // vertical
         if (elementToScroll.scrollHeight > elementToScroll.clientHeight) {
             if (distances.bottom < SCROLL_ZONE_PX) {
@@ -51,6 +71,7 @@ export function makeScroller() {
                 return true;
             }
         }
+
         // horizontal
         if (elementToScroll.scrollWidth > elementToScroll.clientWidth) {
             if (distances.right < SCROLL_ZONE_PX) {
@@ -67,6 +88,7 @@ export function makeScroller() {
                 return true;
             }
         }
+
         resetScrolling();
         return false;
     }

--- a/src/helpers/scroller.ts
+++ b/src/helpers/scroller.ts
@@ -12,7 +12,7 @@ type ScrollingInfo = {
 };
 
 interface Scroller {
-    scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement): boolean;
+    scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement | undefined): boolean;
     resetScrolling(): void;
 }
 
@@ -43,7 +43,7 @@ export function makeScroller(): Scroller {
      * Can be called repeatedly with updated pointer and elementToScroll values without issues
      * @return {boolean} - true if scrolling was needed
      */
-    function scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement): boolean {
+    function scrollIfNeeded(pointer: {x: number; y: number}, elementToScroll: HTMLElement | undefined): boolean {
         if (!elementToScroll) {
             return false;
         }

--- a/src/helpers/styler.ts
+++ b/src/helpers/styler.ts
@@ -174,7 +174,7 @@ export function unDecorateShadowElement(shadowEl: HTMLElement): void {
 }
 
 interface DropZoneIterable {
-  forEach(callback: (dz: HTMLElement) => void): void
+    forEach(callback: (dz: HTMLElement) => void): void;
 }
 
 /**
@@ -183,11 +183,7 @@ interface DropZoneIterable {
  * @param {Function} getStyles - maps a dropzone to a styles object (so the styles can be removed)
  * @param {Function} getClasses - maps a dropzone to a classList
  */
-export function styleActiveDropZones(
-    dropZones: DropZoneIterable,
-    getStyles: GetStyles = () => ({}),
-    getClasses: GetClasses = () => []
-) {
+export function styleActiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles = () => ({}), getClasses: GetClasses = () => []) {
     dropZones.forEach(dz => {
         const styles = getStyles(dz);
         Object.keys(styles).forEach(style => {

--- a/src/helpers/styler.ts
+++ b/src/helpers/styler.ts
@@ -183,7 +183,7 @@ interface DropZoneIterable {
  * @param {Function} getStyles - maps a dropzone to a styles object (so the styles can be removed)
  * @param {Function} getClasses - maps a dropzone to a classList
  */
-export function styleActiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles = () => ({}), getClasses: GetClasses = () => []) {
+export function styleActiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles, getClasses: GetClasses) {
     dropZones.forEach(dz => {
         const styles = getStyles(dz);
         Object.entries(styles).forEach(([property, value]) => {
@@ -200,7 +200,7 @@ export function styleActiveDropZones(dropZones: DropZoneIterable, getStyles: Get
  * @param {Function} getClasses - maps a dropzone to a classList
  */
 
-export function styleInactiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles = () => ({}), getClasses: GetClasses = () => []) {
+export function styleInactiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles, getClasses: GetClasses) {
     dropZones.forEach(dz => {
         const styles = getStyles(dz);
         Object.keys(styles).forEach(style => {

--- a/src/helpers/styler.ts
+++ b/src/helpers/styler.ts
@@ -186,9 +186,8 @@ interface DropZoneIterable {
 export function styleActiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles = () => ({}), getClasses: GetClasses = () => []) {
     dropZones.forEach(dz => {
         const styles = getStyles(dz);
-        Object.keys(styles).forEach(style => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            dz.style[style as any] = styles[style];
+        Object.entries(styles).forEach(([property, value]) => {
+            dz.style.setProperty(property, value);
         });
         getClasses(dz).forEach(c => dz.classList.add(c));
     });
@@ -205,8 +204,7 @@ export function styleInactiveDropZones(dropZones: DropZoneIterable, getStyles: G
     dropZones.forEach(dz => {
         const styles = getStyles(dz);
         Object.keys(styles).forEach(style => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            dz.style[style as any] = "";
+            dz.style.setProperty(style, "");
         });
         getClasses(dz).forEach(c => dz.classList.contains(c) && dz.classList.remove(c));
     });

--- a/src/helpers/styler.ts
+++ b/src/helpers/styler.ts
@@ -19,7 +19,7 @@ function trs(property: string): string {
  * @param {Point} [positionCenterOnXY]
  * @return {Node} - the cloned, styled element
  */
-export function createDraggedElementFrom(originalElement: HTMLElement, positionCenterOnXY: Point): HTMLElement {
+export function createDraggedElementFrom(originalElement: HTMLElement, positionCenterOnXY: Point | undefined): HTMLElement {
     const rect = originalElement.getBoundingClientRect();
     const draggedEl = originalElement.cloneNode(true);
 
@@ -173,6 +173,10 @@ export function unDecorateShadowElement(shadowEl: HTMLElement): void {
     shadowEl.removeAttribute(SHADOW_ELEMENT_ATTRIBUTE_NAME);
 }
 
+interface DropZoneIterable {
+  forEach(callback: (dz: HTMLElement) => void): void
+}
+
 /**
  * will mark the given dropzones as visually active
  * @param {Array<HTMLElement>} dropZones
@@ -180,7 +184,7 @@ export function unDecorateShadowElement(shadowEl: HTMLElement): void {
  * @param {Function} getClasses - maps a dropzone to a classList
  */
 export function styleActiveDropZones(
-    dropZones: HTMLElement[],
+    dropZones: DropZoneIterable,
     getStyles: GetStyles = () => ({}),
     getClasses: GetClasses = () => []
 ) {
@@ -200,7 +204,8 @@ export function styleActiveDropZones(
  * @param {Function} getStyles - maps a dropzone to a styles object
  * @param {Function} getClasses - maps a dropzone to a classList
  */
-export function styleInactiveDropZones(dropZones: HTMLElement[], getStyles: GetStyles = () => ({}), getClasses: GetClasses = () => []) {
+
+export function styleInactiveDropZones(dropZones: DropZoneIterable, getStyles: GetStyles = () => ({}), getClasses: GetClasses = () => []) {
     dropZones.forEach(dz => {
         const styles = getStyles(dz);
         Object.keys(styles).forEach(style => {

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -2,7 +2,7 @@
  * @param {Object} object
  * @return {string}
  */
-export function toString(object) {
+export function toString(object: unknown): string {
     return JSON.stringify(object, null, 2);
 }
 
@@ -11,13 +11,14 @@ export function toString(object) {
  * @param {HTMLElement} node
  * @return {number} - the depth of the node
  */
-export function getDepth(node) {
+export function getDepth(node: HTMLElement): number {
     if (!node) {
         throw new Error("cannot get depth of a falsy node");
     }
     return _getDepth(node, 0);
 }
-function _getDepth(node, countSoFar = 0) {
+
+function _getDepth(node: HTMLElement, countSoFar = 0): number {
     if (!node.parentElement) {
         return countSoFar - 1;
     }
@@ -30,15 +31,17 @@ function _getDepth(node, countSoFar = 0) {
  * @param {Object} objB
  * @return {boolean} - true if objA and objB are shallow equal
  */
-export function areObjectsShallowEqual(objA, objB) {
+export function areObjectsShallowEqual<T>(objA: T, objB: T): boolean {
     if (Object.keys(objA).length !== Object.keys(objB).length) {
         return false;
     }
+
     for (const keyA in objA) {
         if (!{}.hasOwnProperty.call(objB, keyA) || objB[keyA] !== objA[keyA]) {
             return false;
         }
     }
+
     return true;
 }
 
@@ -48,14 +51,16 @@ export function areObjectsShallowEqual(objA, objB) {
  * @param arrB
  * @return {boolean} - whether the arrays are shallow equal
  */
-export function areArraysShallowEqualSameOrder(arrA, arrB) {
+export function areArraysShallowEqualSameOrder<T>(arrA: T[], arrB: T[]): boolean {
     if (arrA.length !== arrB.length) {
         return false;
     }
+
     for (let i = 0; i < arrA.length; i++) {
         if (arrA[i] !== arrB[i]) {
             return false;
         }
     }
+
     return true;
 }

--- a/src/helpers/windowScroller.ts
+++ b/src/helpers/windowScroller.ts
@@ -1,6 +1,7 @@
 import {makeScroller} from "./scroller";
 import {printDebug} from "../constants";
 import {resetIndexesCache} from "./listUtil";
+import {getPointFromEvent} from "./point";
 
 const INTERVAL_MS = 300;
 
@@ -16,16 +17,8 @@ let mousePosition: MousePosition | undefined;
  * // TODO - make private (remove export)
  * @param {{clientX: number, clientY: number}} e
  */
-export function updateMousePosition(e: MouseEvent | TouchEvent) {
-    let c: {clientX: number; clientY: number};
-
-    if ("touches" in e) {
-        c = e.touches[0];
-    } else {
-        c = e;
-    }
-
-    mousePosition = {x: c.clientX, y: c.clientY};
+function updateMousePosition(e: MouseEvent | TouchEvent) {
+    mousePosition = getPointFromEvent(e);
 }
 
 const {scrollIfNeeded, resetScrolling} = makeScroller();

--- a/src/helpers/windowScroller.ts
+++ b/src/helpers/windowScroller.ts
@@ -3,21 +3,36 @@ import {printDebug} from "../constants";
 import {resetIndexesCache} from "./listUtil";
 
 const INTERVAL_MS = 300;
-let mousePosition;
+
+type MousePosition = {
+    x: number;
+    y: number;
+}
+
+let mousePosition: MousePosition | undefined;
 
 /**
  * Do not use this! it is visible for testing only until we get over the issue Cypress not triggering the mousemove listeners
  * // TODO - make private (remove export)
  * @param {{clientX: number, clientY: number}} e
  */
-export function updateMousePosition(e) {
-    const c = e.touches ? e.touches[0] : e;
+export function updateMousePosition(e: MouseEvent | TouchEvent) {
+    let c: { clientX: number; clientY: number };
+
+    if ('touches' in e) {
+        c = e.touches[0];
+    } else {
+        c = e;
+    }
+
     mousePosition = {x: c.clientX, y: c.clientY};
 }
-const {scrollIfNeeded, resetScrolling} = makeScroller();
-let next;
 
-function loop() {
+const {scrollIfNeeded, resetScrolling} = makeScroller();
+
+let next: number | undefined;
+
+function loop(): void {
     if (mousePosition) {
         const scrolled = scrollIfNeeded(mousePosition, document.documentElement);
         if (scrolled) resetIndexesCache();
@@ -28,7 +43,7 @@ function loop() {
 /**
  * will start watching the mouse pointer and scroll the window if it goes next to the edges
  */
-export function armWindowScroller() {
+export function armWindowScroller(): void {
     printDebug(() => "arming window scroller");
     window.addEventListener("mousemove", updateMousePosition);
     window.addEventListener("touchmove", updateMousePosition);
@@ -38,7 +53,7 @@ export function armWindowScroller() {
 /**
  * will stop watching the mouse pointer and won't scroll the window anymore
  */
-export function disarmWindowScroller() {
+export function disarmWindowScroller(): void {
     printDebug(() => "disarming window scroller");
     window.removeEventListener("mousemove", updateMousePosition);
     window.removeEventListener("touchmove", updateMousePosition);

--- a/src/helpers/windowScroller.ts
+++ b/src/helpers/windowScroller.ts
@@ -7,7 +7,7 @@ const INTERVAL_MS = 300;
 type MousePosition = {
     x: number;
     y: number;
-}
+};
 
 let mousePosition: MousePosition | undefined;
 
@@ -17,9 +17,9 @@ let mousePosition: MousePosition | undefined;
  * @param {{clientX: number, clientY: number}} e
  */
 export function updateMousePosition(e: MouseEvent | TouchEvent) {
-    let c: { clientX: number; clientY: number };
+    let c: {clientX: number; clientY: number};
 
-    if ('touches' in e) {
+    if ("touches" in e) {
         c = e.touches[0];
     } else {
         c = e;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -5,6 +5,19 @@ export type Point = {
     y: number;
 };
 
+export type AbsoluteRect = {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+};
+
+export type Rect = Point &
+    AbsoluteRect & {
+        width: number;
+        height: number;
+    };
+
 export type IndexObj = {
     index: number | undefined;
     isProximityBased: boolean;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -56,5 +56,5 @@ export type InternalConfig = {
     dropTargetClasses: string[];
     transformDraggedElement: TransformDraggedElementFunction;
     autoAriaDisabled?: boolean;
-    centerDraggedOnCursor: boolean;
+    centreDraggedOnCursor: boolean;
 };

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,61 +1,60 @@
-import { DndEventInfo, Item, TransformDraggedElementFunction } from "./types";
+import {DndEventInfo, Item, TransformDraggedElementFunction} from "./types";
 
 export type Point = {
-  x: number;
-  y: number;
+    x: number;
+    y: number;
 };
 
 export type IndexObj = {
-  index: number | undefined;
-  isProximityBased: boolean;
+    index: number | undefined;
+    isProximityBased: boolean;
 };
 
 export type GetStyles = (dz: HTMLElement) => Record<string, string>;
 export type GetClasses = (dz: HTMLElement) => string[];
 
 export type FinalizeEvent = CustomEvent<{
-  items: Item[];
-  info: DndEventInfo;
-}>
+    items: Item[];
+    info: DndEventInfo;
+}>;
 
 export type ConsiderEvent = CustomEvent<{
-  items: Item[];
-  info: DndEventInfo;
-}>
+    items: Item[];
+    info: DndEventInfo;
+}>;
 
 export type DraggedEnteredEvent = CustomEvent<{
-  indexObj: IndexObj;
-  draggedEl: Node;
-}>
+    indexObj: IndexObj;
+    draggedEl: Node;
+}>;
 
-export type DraggedLeftEvent = CustomEvent<{
-  draggedEl: Node;
-  } & (
-  { type: 'outsideOfAny' } |
-  { type: 'leftForAnother'; theOtherDz: Node; }
-)>
+export type DraggedLeftEvent = CustomEvent<
+    {
+        draggedEl: Node;
+    } & ({type: "outsideOfAny"} | {type: "leftForAnother"; theOtherDz: Node})
+>;
 
 export type DraggedOverIndexEvent = CustomEvent<{
-  indexObj: IndexObj;
-  draggedEl: Node;
-}>
+    indexObj: IndexObj;
+    draggedEl: Node;
+}>;
 
 export type DraggedLeftDocumentEvent = CustomEvent<{
-  draggedEl: Node;
-}>
+    draggedEl: Node;
+}>;
 
 // the internal representation of the dnd config after default values have been applied
 export type InternalConfig = {
-  items: Item[];
-  type: string;
-  flipDurationMs: number;
-  dropAnimationDurationMs: number;
-  dragDisabled: boolean;
-  morphDisabled: boolean;
-  dropFromOthersDisabled: boolean;
-  dropTargetStyle: Record<string, string>;
-  dropTargetClasses: string[];
-  transformDraggedElement: TransformDraggedElementFunction;
-  autoAriaDisabled?: boolean;
-  centerDraggedOnCursor: boolean;
+    items: Item[];
+    type: string;
+    flipDurationMs: number;
+    dropAnimationDurationMs: number;
+    dragDisabled: boolean;
+    morphDisabled: boolean;
+    dropFromOthersDisabled: boolean;
+    dropTargetStyle: Record<string, string>;
+    dropTargetClasses: string[];
+    transformDraggedElement: TransformDraggedElementFunction;
+    autoAriaDisabled?: boolean;
+    centerDraggedOnCursor: boolean;
 };

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,0 +1,12 @@
+export type Point = {
+  x: number;
+  y: number;
+};
+
+export type IndexObj = {
+  index: number | undefined;
+  isProximityBased: boolean;
+};
+
+export type GetStyles = (dz: HTMLElement) => Record<string, string>;
+export type GetClasses = (dz: HTMLElement) => string[];

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,4 +1,5 @@
 import {DndEventInfo, Item, TransformDraggedElementFunction} from "./types";
+import type { Properties as CSSProperties } from 'csstype';
 
 export type Point = {
     x: number;
@@ -17,7 +18,7 @@ export type IndexObj = {
     isProximityBased: boolean;
 };
 
-export type GetStyles = (dz: HTMLElement) => Record<string, string>;
+export type GetStyles = (dz: HTMLElement) => CSSProperties<string | number>;
 export type GetClasses = (dz: HTMLElement) => string[];
 
 export type FinalizeEvent = CustomEvent<{
@@ -59,7 +60,7 @@ export type InternalConfig = {
     dragDisabled: boolean;
     morphDisabled: boolean;
     dropFromOthersDisabled: boolean;
-    dropTargetStyle: Record<string, string>;
+    dropTargetStyle: CSSProperties<string | number>;
     dropTargetClasses: string[];
     transformDraggedElement: TransformDraggedElementFunction;
     autoAriaDisabled?: boolean;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,5 +1,5 @@
 import {DndEventInfo, Item, TransformDraggedElementFunction} from "./types";
-import type { Properties as CSSProperties } from 'csstype';
+import type {Properties as CSSProperties} from "csstype";
 
 export type Point = {
     x: number;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -12,12 +12,6 @@ export type AbsoluteRect = {
     right: number;
 };
 
-export type Rect = Point &
-    AbsoluteRect & {
-        width: number;
-        height: number;
-    };
-
 export type IndexObj = {
     index: number | undefined;
     isProximityBased: boolean;

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,3 +1,5 @@
+import { DndEventInfo, Item, TransformDraggedElementFunction } from "./types";
+
 export type Point = {
   x: number;
   y: number;
@@ -10,3 +12,34 @@ export type IndexObj = {
 
 export type GetStyles = (dz: HTMLElement) => Record<string, string>;
 export type GetClasses = (dz: HTMLElement) => string[];
+
+export type FinalizeEvent = CustomEvent<{
+  items: Item[];
+  info: DndEventInfo;
+}>
+
+export type ConsiderEvent = CustomEvent<{
+  items: Item[];
+  info: DndEventInfo;
+}>
+
+export type DraggedEnteredEvent = CustomEvent<{
+  indexObj: IndexObj;
+  draggedEl: Node;
+}>
+
+export type DraggedLeftEvent = CustomEvent<{
+  draggedEl: Node;
+  } & (
+  { type: 'outsideOfAny' } |
+  { type: 'leftForAnother'; theOtherDz: Node; }
+)>
+
+export type DraggedOverIndexEvent = CustomEvent<{
+  indexObj: IndexObj;
+  draggedEl: Node;
+}>
+
+export type DraggedLeftDocumentEvent = CustomEvent<{
+  draggedEl: Node;
+}>

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -43,3 +43,19 @@ export type DraggedOverIndexEvent = CustomEvent<{
 export type DraggedLeftDocumentEvent = CustomEvent<{
   draggedEl: Node;
 }>
+
+// the internal representation of the dnd config after default values have been applied
+export type InternalConfig = {
+  items: Item[];
+  type: string;
+  flipDurationMs: number;
+  dropAnimationDurationMs: number;
+  dragDisabled: boolean;
+  morphDisabled: boolean;
+  dropFromOthersDisabled: boolean;
+  dropTargetStyle: Record<string, string>;
+  dropTargetClasses: string[];
+  transformDraggedElement: TransformDraggedElementFunction;
+  autoAriaDisabled?: boolean;
+  centerDraggedOnCursor: boolean;
+};

--- a/src/keyboardAction.js
+++ b/src/keyboardAction.js
@@ -298,8 +298,8 @@ export function dndzone(node, options) {
                 focusedItem.contains(node) ||
                 config.dropFromOthersDisabled ||
                 (focusedDz && config.type !== dzToConfig.get(focusedDz).type)
-                ? -1
-                : 0;
+                    ? -1
+                    : 0;
         } else {
             node.tabIndex = config.zoneTabIndex;
         }

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -34,7 +34,7 @@ import {
 import {areArraysShallowEqualSameOrder, areObjectsShallowEqual, toString} from "./helpers/util";
 import {getBoundingRectNoTransforms} from "./helpers/intersection";
 import { Item, Options } from "./types";
-import { DraggedEnteredEvent, DraggedLeftEvent, DraggedOverIndexEvent, Point } from "./internalTypes";
+import { DraggedEnteredEvent, DraggedLeftEvent, DraggedOverIndexEvent, InternalConfig, Point } from "./internalTypes";
 
 const DEFAULT_DROP_ZONE_TYPE = "--any--";
 const MIN_OBSERVATION_INTERVAL_MS = 100;
@@ -43,16 +43,14 @@ const DEFAULT_DROP_TARGET_STYLE = {
     outline: "rgba(255, 255, 102, 0.7) solid 2px"
 };
 
-type DNDElement = HTMLElement;
-
-let originalDragTarget: DNDElement | undefined;
-let draggedEl: DNDElement | undefined;
+let originalDragTarget: HTMLElement | undefined;
+let draggedEl: HTMLElement | undefined;
 let draggedElData: Item | undefined;
 let draggedElType: string | undefined;
-let originDropZone: DNDElement | undefined;
+let originDropZone: HTMLElement | undefined;
 let originIndex: number | undefined;
 let shadowElData: Item | undefined;
-let shadowElDropZone: DNDElement | undefined;
+let shadowElDropZone: HTMLElement | undefined;
 let dragStartMousePosition: Point | undefined;
 let currentMousePosition: Point | undefined;
 let isWorkingOnPreviousDrag = false;
@@ -61,14 +59,14 @@ let unlockOriginDzMinDimensions: (() => void) | undefined;
 let isDraggedOutsideOfAnyDz = false;
 
 // a map from type to a set of drop-zones
-const typeToDropZones = new Map<string, Set<DNDElement>>();
+const typeToDropZones = new Map<string, Set<HTMLElement>>();
 // important - this is needed because otherwise the config that would be used for everyone is the config of the element that created the event listeners
-const dzToConfig = new Map<DNDElement, Options>();
+const dzToConfig = new Map<HTMLElement, InternalConfig>();
 // this is needed in order to be able to cleanup old listeners and avoid stale closures issues (as the listener is defined within each zone)
 const elToMouseDownListener = new WeakMap();
 
 /* drop-zones registration management */
-function registerDropZone(dropZoneEl: DNDElement, type: string) {
+function registerDropZone(dropZoneEl: HTMLElement, type: string) {
     printDebug(() => "registering drop-zone if absent");
     if (!typeToDropZones.has(type)) {
         typeToDropZones.set(type, new Set());
@@ -81,7 +79,7 @@ function registerDropZone(dropZoneEl: DNDElement, type: string) {
     }
 }
 
-function unregisterDropZone(dropZoneEl: DNDElement, type: string) {
+function unregisterDropZone(dropZoneEl: HTMLElement, type: string) {
     const dropZoneSet = typeToDropZones.get(type);
 
     if (!dropZoneSet) {

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -484,7 +484,7 @@ function getInternalConfig(options: Options): InternalConfig {
         type: options.type ?? DEFAULT_DROP_ZONE_TYPE,
         dragDisabled: options.dragDisabled ?? false,
         morphDisabled: options.morphDisabled ?? false,
-        dropFromOthersDisabled: options.morphDisabled ?? false,
+        dropFromOthersDisabled: options.dropFromOthersDisabled ?? false,
         dropTargetStyle: options.dropTargetStyle ?? DEFAULT_DROP_TARGET_STYLE,
         dropTargetClasses: options.dropTargetClasses ?? [],
         transformDraggedElement: options.transformDraggedElement ?? (() => {}),

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -1,3 +1,4 @@
+import {getInternalConfig} from "./config";
 import {
     decrementActiveDropZoneCount,
     incrementActiveDropZoneCount,
@@ -37,12 +38,8 @@ import {getBoundingRectNoTransforms} from "./helpers/intersection";
 import {Item, Options} from "./types";
 import {DraggedEnteredEvent, DraggedLeftEvent, DraggedOverIndexEvent, InternalConfig, Point} from "./internalTypes";
 
-const DEFAULT_DROP_ZONE_TYPE = "--any--";
 const MIN_OBSERVATION_INTERVAL_MS = 100;
 const MIN_MOVEMENT_BEFORE_DRAG_START_PX = 3;
-const DEFAULT_DROP_TARGET_STYLE = {
-    outline: "rgba(255, 255, 102, 0.7) solid 2px"
-};
 
 let originalDragTarget: HTMLElement | undefined;
 let draggedEl: HTMLElement | undefined;
@@ -467,22 +464,6 @@ function cleanupPostDrop() {
     finalizingPreviousDrag = false;
     unlockOriginDzMinDimensions = undefined;
     isDraggedOutsideOfAnyDz = false;
-}
-
-function getInternalConfig(options: Options): InternalConfig {
-    return {
-        items: [...options.items],
-        flipDurationMs: options.flipDurationMs ?? 0,
-        dropAnimationDurationMs: options.flipDurationMs ?? 0,
-        type: options.type ?? DEFAULT_DROP_ZONE_TYPE,
-        dragDisabled: options.dragDisabled ?? false,
-        morphDisabled: options.morphDisabled ?? false,
-        dropFromOthersDisabled: options.dropFromOthersDisabled ?? false,
-        dropTargetStyle: options.dropTargetStyle ?? DEFAULT_DROP_TARGET_STYLE,
-        dropTargetClasses: options.dropTargetClasses ?? [],
-        transformDraggedElement: options.transformDraggedElement ?? (() => {}),
-        centreDraggedOnCursor: options.centreDraggedOnCursor ?? false
-    };
 }
 
 export function dndzone(node: HTMLElement, options: Options) {

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -499,7 +499,7 @@ export function dndzone(node: HTMLElement, options: Options) {
     };
 
     printDebug(() => [`dndzone good to go options: ${toString(options)}, config: ${toString(config)}`, {node}]);
-    const elToIdx = new Map();
+    const elToIdx = new Map<HTMLElement, number>();
 
     function addMaybeListeners() {
         window.addEventListener("mousemove", handleMouseMoveMaybeDragStart, {passive: false});
@@ -507,12 +507,14 @@ export function dndzone(node: HTMLElement, options: Options) {
         window.addEventListener("mouseup", handleFalseAlarm, {passive: false});
         window.addEventListener("touchend", handleFalseAlarm, {passive: false});
     }
+
     function removeMaybeListeners() {
         window.removeEventListener("mousemove", handleMouseMoveMaybeDragStart);
         window.removeEventListener("touchmove", handleMouseMoveMaybeDragStart);
         window.removeEventListener("mouseup", handleFalseAlarm);
         window.removeEventListener("touchend", handleFalseAlarm);
     }
+
     function handleFalseAlarm() {
         removeMaybeListeners();
         originalDragTarget = undefined;
@@ -575,13 +577,17 @@ export function dndzone(node: HTMLElement, options: Options) {
         printDebug(() => [`drag start config: ${toString(config)}`, originalDragTarget]);
         isWorkingOnPreviousDrag = true;
 
-        // initialising globals
-        const currentIdx = elToIdx.get(originalDragTarget);
-        originIndex = currentIdx;
-
         if (!originalDragTarget) {
           return;
         }
+
+        // initialising globals
+        const currentIdx = elToIdx.get(originalDragTarget);
+
+        if (typeof currentIdx !== 'number') {
+          return;
+        }
+        originIndex = currentIdx;
 
         originDropZone = originalDragTarget.parentElement ?? undefined;
 
@@ -765,6 +771,7 @@ export function dndzone(node: HTMLElement, options: Options) {
             elToIdx.set(draggableEl, idx);
         }
     }
+
     configure(options);
 
     return {

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -33,8 +33,8 @@ import {
 } from "./helpers/dispatcher";
 import {areArraysShallowEqualSameOrder, areObjectsShallowEqual, toString} from "./helpers/util";
 import {getBoundingRectNoTransforms} from "./helpers/intersection";
-import { Item, Options } from "./types";
-import { DraggedEnteredEvent, DraggedLeftEvent, DraggedOverIndexEvent, InternalConfig, Point } from "./internalTypes";
+import {Item, Options} from "./types";
+import {DraggedEnteredEvent, DraggedLeftEvent, DraggedOverIndexEvent, InternalConfig, Point} from "./internalTypes";
 
 const DEFAULT_DROP_ZONE_TYPE = "--any--";
 const MIN_OBSERVATION_INTERVAL_MS = 100;
@@ -75,7 +75,7 @@ function registerDropZone(dropZoneEl: HTMLElement, type: string) {
     const dropZoneSet = typeToDropZones.get(type);
 
     if (dropZoneSet && dropZoneSet.has(dropZoneEl)) {
-      incrementActiveDropZoneCount();
+        incrementActiveDropZoneCount();
     }
 }
 
@@ -83,16 +83,16 @@ function unregisterDropZone(dropZoneEl: HTMLElement, type: string) {
     const dropZoneSet = typeToDropZones.get(type);
 
     if (!dropZoneSet) {
-      return;
+        return;
     }
 
     dropZoneSet.delete(dropZoneEl);
     decrementActiveDropZoneCount();
 
     if (dropZoneSet.size > 0) {
-      typeToDropZones.set(type, dropZoneSet);
+        typeToDropZones.set(type, dropZoneSet);
     } else {
-      typeToDropZones.delete(type);
+        typeToDropZones.delete(type);
     }
 }
 
@@ -102,17 +102,17 @@ function watchDraggedElement() {
     armWindowScroller();
 
     if (!draggedEl) {
-      return;
+        return;
     }
 
-    if (typeof draggedElType !== 'string') {
-      return;
+    if (typeof draggedElType !== "string") {
+        return;
     }
 
     const dropZones = typeToDropZones.get(draggedElType);
 
     if (!dropZones) {
-      return;
+        return;
     }
 
     for (const dz of dropZones) {
@@ -126,7 +126,9 @@ function watchDraggedElement() {
     // it is important that we don't have an interval that is faster than the flip duration because it can cause elements to jump bach and forth
     const observationIntervalMs = Math.max(
         MIN_OBSERVATION_INTERVAL_MS,
-        ...Array.from(dropZones.keys()).map(dz => dzToConfig.get(dz)?.dropAnimationDurationMs).filter((ms): ms is number => typeof ms === 'number')
+        ...Array.from(dropZones.keys())
+            .map(dz => dzToConfig.get(dz)?.dropAnimationDurationMs)
+            .filter((ms): ms is number => typeof ms === "number")
     );
 
     observe(draggedEl, dropZones, observationIntervalMs * 1.07);
@@ -137,13 +139,13 @@ function unWatchDraggedElement() {
     disarmWindowScroller();
 
     if (!draggedElType) {
-      return;
+        return;
     }
 
     const dropZones = typeToDropZones.get(draggedElType);
 
     if (!dropZones) {
-      return;
+        return;
     }
 
     for (const dz of dropZones) {
@@ -173,17 +175,17 @@ function handleDraggedEntered(e: DraggedEnteredEvent) {
     const currentTarget = e.currentTarget;
 
     if (!(currentTarget instanceof HTMLElement)) {
-      return;
+        return;
     }
 
-    const config = dzToConfig.get(currentTarget)
+    const config = dzToConfig.get(currentTarget);
 
     if (!config) {
-      return;
+        return;
     }
 
-    let { items } = config;
-    const { dropFromOthersDisabled } = config;
+    let {items} = config;
+    const {dropFromOthersDisabled} = config;
 
     if (dropFromOthersDisabled && e.currentTarget !== originDropZone) {
         printDebug(() => "ignoring dragged entered because drop is currently disabled");
@@ -197,7 +199,7 @@ function handleDraggedEntered(e: DraggedEnteredEvent) {
     printDebug(() => `dragged entered items ${toString(items)}`);
 
     if (!draggedElData || !originDropZone) {
-      return;
+        return;
     }
 
     if (draggedElData && originDropZone && originDropZone !== e.currentTarget) {
@@ -221,8 +223,8 @@ function handleDraggedEntered(e: DraggedEnteredEvent) {
     const shadowElIdx = isProximityBased && index === currentTarget.children.length - 1 ? index + 1 : index;
     shadowElDropZone = currentTarget;
 
-    if (typeof shadowElIdx !== 'number' || shadowElData === undefined) {
-      return;
+    if (typeof shadowElIdx !== "number" || shadowElData === undefined) {
+        return;
     }
 
     items.splice(shadowElIdx, 0, shadowElData);
@@ -232,24 +234,24 @@ function handleDraggedEntered(e: DraggedEnteredEvent) {
 function handleDraggedLeft(e: DraggedLeftEvent) {
     // dealing with a rare race condition on extremely rapid clicking and dropping
     if (!isWorkingOnPreviousDrag) {
-      return;
+        return;
     }
 
     printDebug(() => ["dragged left", e.currentTarget, e.detail]);
 
-  const currentTarget = e.currentTarget;
+    const currentTarget = e.currentTarget;
 
     if (!(currentTarget instanceof HTMLElement)) {
-      return;
+        return;
     }
 
-    const config = dzToConfig.get(currentTarget)
+    const config = dzToConfig.get(currentTarget);
 
     if (!config) {
-      return;
+        return;
     }
 
-    const { items, dropFromOthersDisabled } = config;
+    const {items, dropFromOthersDisabled} = config;
 
     if (dropFromOthersDisabled && currentTarget !== originDropZone && currentTarget !== shadowElDropZone) {
         printDebug(() => "drop is currently disabled");
@@ -263,14 +265,14 @@ function handleDraggedLeft(e: DraggedLeftEvent) {
     let isOutsideAnyDz = false;
 
     if (e.detail.type === DRAGGED_LEFT_TYPES.OUTSIDE_OF_ANY) {
-      isOutsideAnyDz = true;
+        isOutsideAnyDz = true;
     } else if (e.detail.theOtherDz !== originDropZone && e.detail.theOtherDz instanceof HTMLElement) {
-      const otherDzConig = dzToConfig.get(e.detail.theOtherDz);
+        const otherDzConig = dzToConfig.get(e.detail.theOtherDz);
 
-      if (otherDzConig) {
-        // default value is false, so cast boolean | undefined to boolean
-        isOutsideAnyDz = !!otherDzConig.dropFromOthersDisabled;
-      }
+        if (otherDzConig) {
+            // default value is false, so cast boolean | undefined to boolean
+            isOutsideAnyDz = !!otherDzConig.dropFromOthersDisabled;
+        }
     }
 
     if (isOutsideAnyDz && originDropZone) {
@@ -280,7 +282,7 @@ function handleDraggedLeft(e: DraggedLeftEvent) {
 
         const originDzConfig = dzToConfig.get(originDropZone);
 
-        if (draggedElData && originDzConfig && typeof originIndex === 'number') {
+        if (draggedElData && originDzConfig && typeof originIndex === "number") {
             const originZoneItems = originDzConfig.items;
             originZoneItems.splice(originIndex, 0, shadowItem);
             dispatchConsiderEvent(originDropZone, originZoneItems, {
@@ -292,30 +294,29 @@ function handleDraggedLeft(e: DraggedLeftEvent) {
     }
 
     if (draggedElData) {
-      // for the origin dz, when the dragged is outside of any, this will be fired in addition to the previous. this is for simplicity
-      dispatchConsiderEvent(currentTarget, items, {
-          trigger: TRIGGERS.DRAGGED_LEFT,
-          id: draggedElData[ITEM_ID_KEY],
-          source: SOURCES.POINTER
-      });
+        // for the origin dz, when the dragged is outside of any, this will be fired in addition to the previous. this is for simplicity
+        dispatchConsiderEvent(currentTarget, items, {
+            trigger: TRIGGERS.DRAGGED_LEFT,
+            id: draggedElData[ITEM_ID_KEY],
+            source: SOURCES.POINTER
+        });
     }
 }
 
 function handleDraggedIsOverIndex(e: DraggedOverIndexEvent) {
     printDebug(() => ["dragged is over index", e.currentTarget, e.detail]);
 
-  const currentTarget = e.currentTarget;
+    const currentTarget = e.currentTarget;
 
     if (!(currentTarget instanceof HTMLElement)) {
-      return;
+        return;
     }
 
     const config = dzToConfig.get(currentTarget);
 
     if (!config) {
-      return;
+        return;
     }
-
 
     const {items, dropFromOthersDisabled} = config;
     if (dropFromOthersDisabled && e.currentTarget !== originDropZone) {
@@ -326,18 +327,18 @@ function handleDraggedIsOverIndex(e: DraggedOverIndexEvent) {
     const {index} = e.detail.indexObj;
     const shadowElIdx = findShadowElementIdx(items);
 
-    if (shadowElData && draggedElData && typeof index === 'number') {
-      items.splice(shadowElIdx, 1);
-      items.splice(index, 0, shadowElData);
-      dispatchConsiderEvent(currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER});
+    if (shadowElData && draggedElData && typeof index === "number") {
+        items.splice(shadowElIdx, 1);
+        items.splice(index, 0, shadowElData);
+        dispatchConsiderEvent(currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER});
     }
 }
 
 function getPointFromEvent(e: MouseEvent | TouchEvent): Point {
-    if ('touches' in e) {
-      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    if ("touches" in e) {
+        return {x: e.touches[0].clientX, y: e.touches[0].clientY};
     } else {
-      return { x: e.clientX, y: e.clientY };
+        return {x: e.clientX, y: e.clientY};
     }
 }
 
@@ -346,7 +347,7 @@ function handleMouseMove(e: MouseEvent | TouchEvent) {
     e.preventDefault();
 
     if (!draggedEl || !dragStartMousePosition) {
-      return;
+        return;
     }
 
     currentMousePosition = getPointFromEvent(e);
@@ -367,7 +368,7 @@ function handleDrop() {
     unWatchDraggedElement();
 
     if (draggedEl) {
-      moveDraggedElementToWasDroppedState(draggedEl);
+        moveDraggedElementToWasDroppedState(draggedEl);
     }
 
     if (!shadowElDropZone) {
@@ -377,34 +378,34 @@ function handleDrop() {
     printDebug(() => ["dropped in dz", shadowElDropZone]);
 
     if (!shadowElDropZone) {
-      return;
+        return;
     }
 
     const shadowElConfig = dzToConfig.get(shadowElDropZone);
 
     if (!shadowElConfig) {
-      return;
+        return;
     }
 
-    let { items } = shadowElConfig;
-    const { type } = shadowElConfig;
+    let {items} = shadowElConfig;
+    const {type} = shadowElConfig;
 
     if (type) {
-      const dropZones = typeToDropZones.get(type);
+        const dropZones = typeToDropZones.get(type);
 
-      if (dropZones) {
-        styleInactiveDropZones(
-          dropZones,
-          dz => dzToConfig.get(dz)?.dropTargetStyle ?? {},
-          dz => dzToConfig.get(dz)?.dropTargetClasses ?? []
-        );
-      }
+        if (dropZones) {
+            styleInactiveDropZones(
+                dropZones,
+                dz => dzToConfig.get(dz)?.dropTargetStyle ?? {},
+                dz => dzToConfig.get(dz)?.dropTargetClasses ?? []
+            );
+        }
     }
 
     let shadowElIdx = findShadowElementIdx(items);
     // the handler might remove the shadow element, ex: dragula like copy on drag
-    if (shadowElIdx === -1 && typeof originIndex === 'number') {
-       shadowElIdx = originIndex;
+    if (shadowElIdx === -1 && typeof originIndex === "number") {
+        shadowElIdx = originIndex;
     }
 
     items = items.map(item => (item[SHADOW_ITEM_MARKER_PROPERTY_NAME] && draggedElData ? draggedElData : item));
@@ -413,11 +414,11 @@ function handleDrop() {
         unlockOriginDzMinDimensions?.();
 
         if (shadowElDropZone && draggedElData) {
-          dispatchFinalizeEvent(shadowElDropZone, items, {
-              trigger: isDraggedOutsideOfAnyDz ? TRIGGERS.DROPPED_OUTSIDE_OF_ANY : TRIGGERS.DROPPED_INTO_ZONE,
-              id: draggedElData[ITEM_ID_KEY],
-              source: SOURCES.POINTER
-          });
+            dispatchFinalizeEvent(shadowElDropZone, items, {
+                trigger: isDraggedOutsideOfAnyDz ? TRIGGERS.DROPPED_OUTSIDE_OF_ANY : TRIGGERS.DROPPED_INTO_ZONE,
+                id: draggedElData[ITEM_ID_KEY],
+                source: SOURCES.POINTER
+            });
         }
 
         if (draggedElData && originDropZone && shadowElDropZone !== originDropZone) {
@@ -431,7 +432,7 @@ function handleDrop() {
         const child = shadowElDropZone?.children[shadowElIdx];
 
         if (child && child instanceof HTMLElement) {
-          unDecorateShadowElement(child);
+            unDecorateShadowElement(child);
         }
         cleanupPostDrop();
     }
@@ -442,26 +443,26 @@ function handleDrop() {
 // helper function for handleDrop
 function animateDraggedToFinalPosition(shadowElIdx: number, callback: () => void) {
     if (!shadowElDropZone) {
-      return;
+        return;
     }
 
-  const child = shadowElDropZone.children[shadowElIdx];
+    const child = shadowElDropZone.children[shadowElIdx];
 
-  if (child && child instanceof HTMLElement && draggedEl) {
-    const shadowElRect = getBoundingRectNoTransforms(child);
-    const newTransform = {
-        x: shadowElRect.left - parseFloat(draggedEl.style.left),
-        y: shadowElRect.top - parseFloat(draggedEl.style.top)
-    };
+    if (child && child instanceof HTMLElement && draggedEl) {
+        const shadowElRect = getBoundingRectNoTransforms(child);
+        const newTransform = {
+            x: shadowElRect.left - parseFloat(draggedEl.style.left),
+            y: shadowElRect.top - parseFloat(draggedEl.style.top)
+        };
 
-    const config = dzToConfig.get(shadowElDropZone);
+        const config = dzToConfig.get(shadowElDropZone);
 
-    const dropAnimationDurationMs = config?.dropAnimationDurationMs ?? 0;
-    const transition = `transform ${dropAnimationDurationMs}ms ease`;
-    draggedEl.style.transition = draggedEl.style.transition ? draggedEl.style.transition + "," + transition : transition;
-    draggedEl.style.transform = `translate3d(${newTransform.x}px, ${newTransform.y}px, 0)`;
-    window.setTimeout(callback, dropAnimationDurationMs);
-  }
+        const dropAnimationDurationMs = config?.dropAnimationDurationMs ?? 0;
+        const transition = `transform ${dropAnimationDurationMs}ms ease`;
+        draggedEl.style.transition = draggedEl.style.transition ? draggedEl.style.transition + "," + transition : transition;
+        draggedEl.style.transform = `translate3d(${newTransform.x}px, ${newTransform.y}px, 0)`;
+        window.setTimeout(callback, dropAnimationDurationMs);
+    }
 }
 
 /* cleanup */
@@ -485,7 +486,7 @@ function cleanupPostDrop() {
 }
 
 export function dndzone(node: HTMLElement, options: Options) {
-    const config: Omit<Options, 'items'> & { items: Options['items'] | undefined }  = {
+    const config: Omit<Options, "items"> & {items: Options["items"] | undefined} = {
         items: undefined,
         type: undefined,
         flipDurationMs: 0,
@@ -527,7 +528,7 @@ export function dndzone(node: HTMLElement, options: Options) {
         currentMousePosition = getPointFromEvent(e);
 
         if (!dragStartMousePosition) {
-          return;
+            return;
         }
 
         if (
@@ -545,7 +546,7 @@ export function dndzone(node: HTMLElement, options: Options) {
         const target = e.currentTarget;
 
         if (!(currentTarget instanceof HTMLElement) || !(target instanceof HTMLElement)) {
-          return;
+            return;
         }
 
         if (target !== currentTarget && target instanceof HTMLInputElement) {
@@ -554,7 +555,7 @@ export function dndzone(node: HTMLElement, options: Options) {
         }
 
         // prevents responding to any button but left click which equals 0 (which is falsy)
-        if ('button' in e && e.button) {
+        if ("button" in e && e.button) {
             printDebug(() => `ignoring none left click button: ${e.button}`);
             return;
         }
@@ -578,21 +579,21 @@ export function dndzone(node: HTMLElement, options: Options) {
         isWorkingOnPreviousDrag = true;
 
         if (!originalDragTarget) {
-          return;
+            return;
         }
 
         // initialising globals
         const currentIdx = elToIdx.get(originalDragTarget);
 
-        if (typeof currentIdx !== 'number') {
-          return;
+        if (typeof currentIdx !== "number") {
+            return;
         }
         originIndex = currentIdx;
 
         originDropZone = originalDragTarget.parentElement ?? undefined;
 
         if (!originDropZone) {
-          return;
+            return;
         }
 
         /** @type {ShadowRoot | HTMLDocument} */
@@ -601,15 +602,15 @@ export function dndzone(node: HTMLElement, options: Options) {
         let originDropZoneRoot: Node;
 
         if (rootNode instanceof Document) {
-          originDropZoneRoot = rootNode.body;
+            originDropZoneRoot = rootNode.body;
         } else {
-          originDropZoneRoot = rootNode;
+            originDropZoneRoot = rootNode;
         }
-        
+
         const {items, type, centreDraggedOnCursor} = config;
 
         if (!items) {
-          return;
+            return;
         }
 
         draggedElData = {...items[currentIdx]};
@@ -630,8 +631,8 @@ export function dndzone(node: HTMLElement, options: Options) {
                 watchDraggedElement();
 
                 if (originalDragTarget) {
-                  hideOriginalDragTarget(originalDragTarget);
-                  originDropZoneRoot.appendChild(originalDragTarget);
+                    hideOriginalDragTarget(originalDragTarget);
+                    originDropZoneRoot.appendChild(originalDragTarget);
                 }
             } else {
                 window.requestAnimationFrame(keepOriginalElementInDom);
@@ -641,26 +642,26 @@ export function dndzone(node: HTMLElement, options: Options) {
         window.requestAnimationFrame(keepOriginalElementInDom);
 
         if (type) {
-      const dropZones = typeToDropZones.get(type);
+            const dropZones = typeToDropZones.get(type);
 
-      if (dropZones) {
-        const activeDropZones = Array.from(dropZones).filter(dz => {
-          if (dz === originDropZone) {
-            return true;
-          }
+            if (dropZones) {
+                const activeDropZones = Array.from(dropZones).filter(dz => {
+                    if (dz === originDropZone) {
+                        return true;
+                    }
 
-          const dropDisabled = dzToConfig.get(dz)?.dropFromOthersDisabled
+                    const dropDisabled = dzToConfig.get(dz)?.dropFromOthersDisabled;
 
-          return !dropDisabled;
-        });
+                    return !dropDisabled;
+                });
 
-        styleActiveDropZones(
-          activeDropZones,
-          dz => dzToConfig.get(dz)?.dropTargetStyle ?? {},
-          dz => dzToConfig.get(dz)?.dropTargetClasses ?? []
-        )
-      }
-    }
+                styleActiveDropZones(
+                    activeDropZones,
+                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? {},
+                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? []
+                );
+            }
+        }
 
         // removing the original element by removing its data entry
         items.splice(currentIdx, 1, placeHolderElData);
@@ -726,14 +727,14 @@ export function dndzone(node: HTMLElement, options: Options) {
             if (dropFromOthersDisabled) {
                 styleInactiveDropZones(
                     [node],
-                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? config['dropTargetStyle'] ?? {},
-                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? config['dropTargetClasses'] ?? [],
+                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? config["dropTargetStyle"] ?? {},
+                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? config["dropTargetClasses"] ?? []
                 );
             } else {
                 styleActiveDropZones(
                     [node],
-                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? config['dropTargetStyle'] ?? {},
-                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? config['dropTargetClasses'] ?? [],
+                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? config["dropTargetStyle"] ?? {},
+                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? config["dropTargetClasses"] ?? []
                 );
             }
         }

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -9,6 +9,7 @@ import {
     TRIGGERS
 } from "./constants";
 import {observe, unobserve} from "./helpers/observer";
+import {getPointFromEvent} from "./helpers/point";
 import {armWindowScroller, disarmWindowScroller} from "./helpers/windowScroller";
 import {
     createDraggedElementFrom,
@@ -322,14 +323,6 @@ function handleDraggedIsOverIndex(e: DraggedOverIndexEvent) {
         items.splice(shadowElIdx, 1);
         items.splice(index, 0, shadowElData);
         dispatchConsiderEvent(currentTarget, items, {trigger: TRIGGERS.DRAGGED_OVER_INDEX, id: draggedElData[ITEM_ID_KEY], source: SOURCES.POINTER});
-    }
-}
-
-function getPointFromEvent(e: MouseEvent | TouchEvent): Point {
-    if ("touches" in e) {
-        return {x: e.touches[0].clientX, y: e.touches[0].clientY};
-    } else {
-        return {x: e.clientX, y: e.clientY};
     }
 }
 

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -63,7 +63,7 @@ const typeToDropZones = new Map<string, Set<HTMLElement>>();
 // important - this is needed because otherwise the config that would be used for everyone is the config of the element that created the event listeners
 const dzToConfig = new Map<HTMLElement, InternalConfig>();
 // this is needed in order to be able to cleanup old listeners and avoid stale closures issues (as the listener is defined within each zone)
-const elToMouseDownListener = new WeakMap();
+const elToMouseDownListener = new WeakMap<HTMLElement, (e: MouseEvent | TouchEvent) => void>();
 
 /* drop-zones registration management */
 function registerDropZone(dropZoneEl: HTMLElement, type: string) {
@@ -745,8 +745,13 @@ export function dndzone(node: HTMLElement, options: Options) {
                 continue;
             }
 
-            draggableEl.removeEventListener("mousedown", elToMouseDownListener.get(draggableEl));
-            draggableEl.removeEventListener("touchstart", elToMouseDownListener.get(draggableEl));
+            const draggableElMouseDownListener = elToMouseDownListener.get(draggableEl);
+
+            if (draggableElMouseDownListener) {
+                draggableEl.removeEventListener("mousedown", draggableElMouseDownListener);
+                draggableEl.removeEventListener("touchstart", draggableElMouseDownListener);
+            }
+
             if (!newConfig.dragDisabled) {
                 draggableEl.addEventListener("mousedown", handleMouseDown);
                 draggableEl.addEventListener("touchstart", handleMouseDown);

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -682,7 +682,7 @@ export function dndzone(node: HTMLElement, options: Options) {
 
     function configure(newConfig: InternalConfig, oldConfig?: InternalConfig) {
         if (oldConfig && oldConfig.type !== newConfig.type) {
-            unregisterDropZone(node, config.type);
+            unregisterDropZone(node, oldConfig.type);
         }
 
         registerDropZone(node, newConfig.type);
@@ -712,20 +712,20 @@ export function dndzone(node: HTMLElement, options: Options) {
                 styleInactiveDropZones(
                     [node],
                     dz => dzToConfig.get(dz)?.dropTargetStyle ?? newConfig.dropTargetStyle,
-                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? config.dropTargetClasses
+                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? newConfig.dropTargetClasses
                 );
             } else {
                 styleActiveDropZones(
                     [node],
-                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? config.dropTargetStyle,
-                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? config.dropTargetClasses
+                    dz => dzToConfig.get(dz)?.dropTargetStyle ?? newConfig.dropTargetStyle,
+                    dz => dzToConfig.get(dz)?.dropTargetClasses ?? newConfig.dropTargetClasses
                 );
             }
         }
 
-        dzToConfig.set(node, config);
+        dzToConfig.set(node, newConfig);
 
-        const shadowElIdx = findShadowElementIdx(config.items);
+        const shadowElIdx = findShadowElementIdx(newConfig.items);
 
         for (let idx = 0; idx < node.children.length; idx++) {
             const draggableEl = node.children[idx];
@@ -738,7 +738,7 @@ export function dndzone(node: HTMLElement, options: Options) {
             if (idx === shadowElIdx) {
                 if (draggedEl && !newConfig.morphDisabled && currentMousePosition) {
                     morphDraggedElementToBeLike(draggedEl, draggableEl, currentMousePosition.x, currentMousePosition.y, () =>
-                        config.transformDraggedElement(draggedEl, draggedElData, idx)
+                        newConfig.transformDraggedElement(draggedEl, draggedElData, idx)
                     );
                 }
                 decorateShadowEl(draggableEl);

--- a/src/pointerAction.ts
+++ b/src/pointerAction.ts
@@ -763,6 +763,8 @@ export function dndzone(node: HTMLElement, options: Options) {
         }
     }
 
+    configure(config);
+
     return {
         update: (newOptions: Options) => {
             printDebug(() => `pointer dndzone will update newOptions: ${toString(newOptions)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface Options {
     transformDraggedElement?: TransformDraggedElementFunction;
     autoAriaDisabled?: boolean;
     centreDraggedOnCursor?: boolean;
+    dropAnimationDurationMs?: number;
 }
 
 export interface DndEventInfo {
@@ -32,4 +33,3 @@ export type DndEvent = {
     items: Item[];
     info: DndEventInfo;
 };
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Properties as CSSProperties } from 'csstype';
+import type {Properties as CSSProperties} from "csstype";
 
 export type TransformDraggedElementFunction = (
     element?: HTMLElement, // the dragged element.
@@ -24,7 +24,7 @@ export interface Options {
     centreDraggedOnCursor?: boolean;
     dropAnimationDurationMs?: number;
 }
-  
+
 export interface DndEventInfo {
     trigger: string; // the type of dnd event that took place
     id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Properties as CSSProperties } from 'csstype';
+
 export type TransformDraggedElementFunction = (
     element?: HTMLElement, // the dragged element.
     draggedElementData?: Item, // the data of the item from the items array
@@ -16,13 +18,13 @@ export interface Options {
     dropFromOthersDisabled?: boolean;
     zoneTabIndex?: number; // set the tabindex of the list container when not dragging
     dropTargetClasses?: string[];
-    dropTargetStyle?: Record<string, string>;
+    dropTargetStyle?: CSSProperties<string | number>;
     transformDraggedElement?: TransformDraggedElementFunction;
     autoAriaDisabled?: boolean;
     centreDraggedOnCursor?: boolean;
     dropAnimationDurationMs?: number;
 }
-
+  
 export interface DndEventInfo {
     trigger: string; // the type of dnd event that took place
     id: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,7 @@
     /* Modules */
     "module": "es6",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -628,6 +628,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+csstype@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.0.tgz#4ddcac3718d787cf9df0d1b7d15033925c8f29f2"
+  integrity sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==
+
 cypress@^4.5.0:
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.12.1.tgz#0ead1b9f4c0917d69d8b57f996b6e01fe693b6ec"


### PR DESCRIPTION
- add zero-config rollup setup, typescript
- add typescript eslint setup
- tweak warnings
- convert a few files to ts to test
- emit declaration
- prevent publishing src (svelte just uses transpiled .js files w/o rollup)
- v0.9.16
- move types options to separate file, export from index
- v0.9.17
- v0.9.18
- v0.9.19
- redo build script
- move all helpers to typescript
- add global definition for events emitted on HTMLElement and Window
- add missing config types
- fixup for global defs
- tweak types for styler
- initial conversion of pointerAction to ts
- add InternalConfig type
- rename DNDElement -> HTMLElement, use InternalConfig
- fix elToIdx type
- add tsconfig to prettier ignore
- run prettier (no other code changes part of this commit)
- fix type name
- use new setup for running config change side effects
- cleanup weakmap in pointerAction
- replace reference to `config` with `newConfig`
- v0.9.20-test
